### PR TITLE
Fix workflow pushes by pulling before commit

### DIFF
--- a/.github/workflows/news_pipeline.yml
+++ b/.github/workflows/news_pipeline.yml
@@ -41,6 +41,7 @@ jobs:
           author_name: 'github-actions'
           author_email: 'github-actions@github.com'
           message: 'chore: update health.json'
+          pull: true
 
       - name: Generate latest briefing
         run: python generate_latest.py
@@ -51,3 +52,4 @@ jobs:
           author_name: 'github-actions'
           author_email: 'github-actions@github.com'
           message: 'chore: update latest.txt'
+          pull: true

--- a/.github/workflows/test_feeds.yml
+++ b/.github/workflows/test_feeds.yml
@@ -48,3 +48,4 @@ jobs:
           author_name: 'github-actions'
           author_email: 'github-actions@github.com'
           message: 'chore: update health.json'
+          pull: true

--- a/news_pipeline.yml
+++ b/news_pipeline.yml
@@ -41,6 +41,7 @@ jobs:
           author_name: 'github-actions'
           author_email: 'github-actions@github.com'
           message: 'chore: update health.json'
+          pull: true
 
       - name: Generate latest briefing
         run: python generate_latest.py
@@ -51,3 +52,4 @@ jobs:
           author_name: 'github-actions'
           author_email: 'github-actions@github.com'
           message: 'chore: update latest.txt'
+          pull: true


### PR DESCRIPTION
## Summary
- allow the `EndBug/add-and-commit` steps in all workflows to pull the
  latest remote changes before committing

## Testing
- `python test_feeds.py` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_685d89ed2d6c83229660fd283d55a7ff