### PR TITLE
Add architecture overview and display briefing

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,26 @@
+# System Architecture
+
+This repository powers a small static site that publishes a daily news briefing and feed health dashboard. It demonstrates the kind of automation and dynamic content you might expect from a mid‑range website project.
+
+```
++------------+        +---------------+         +------------------+
+|  GitHub    |  CI    |  Python       |  Data   |  Static Site      |
+|  Actions   +------->|  Scripts      +-------> |  (GitHub Pages)   |
++------------+        +---------------+         +------------------+
+        ^                        |                         |
+        |                        v                         v
+        |                 RSS Feeds & APIs           index.html + assets
+        |                        |
+        +------------------------+
+```
+
+## Components
+
+1. **RSS Ingestion** – `generate_latest.py` fetches grouped RSS feeds. Articles from the last five days are summarised using a Transformer model and written to `latest.txt`.
+2. **Feed Health** – `test_feeds.py` checks primary and backup feeds defined in `feeds.yaml`. Results are stored in `health.json`.
+3. **Uptime Pings** – the `ping_canadian_feeds.yml` workflow records hourly availability of key Canadian feeds into `uptime.json`.
+4. **Static Dashboard** – `index.html` loads the JSON files via JavaScript and presents the health table, uptime percentages and the latest briefing.
+5. **Automation** – `news_pipeline.yml` runs on a schedule to refresh the data and commit the updated JSON and text files back to the repository.
+6. **Deployment** – GitHub Pages (see `pages-build-deployment.yml`) publishes the repository contents, turning the static assets into a publicly accessible website.
+
+Together these components deliver a lightweight news dashboard with automated data collection. The design can be expanded with additional services, databases or a CMS as project requirements grow.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # hc-news-briefing-feed.github.io
-Daily news briefing feed
+
+This repository hosts a lightweight news dashboard that publishes a daily briefing and monitors the health of several RSS feeds.  The site is deployed via GitHub Pages and the data is refreshed automatically using GitHub Actions.
+
+See [ARCHITECTURE.md](ARCHITECTURE.md) for an overview of how the pieces fit together.

--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
     .bad  { color: red; }
     #uptime-list { margin-top: 1rem; list-style: none; padding: 0; }
     #uptime-list li { margin-bottom: 0.5rem; }
+    #latest-briefing { white-space: pre-wrap; border: 1px solid #ccc; padding: 1rem; background: #f9f9f9; margin-top: 1rem; }
   </style>
 </head>
 <body>
@@ -28,6 +29,9 @@
 
   <h2>Canadian Feed Uptime (past 7 days)</h2>
   <ul id="uptime-list"></ul>
+
+  <h2>Latest News Briefing</h2>
+  <pre id="latest-briefing">Loading latest briefing...</pre>
 
   <script>
     document.addEventListener('DOMContentLoaded', async () => {
@@ -92,6 +96,19 @@
         li.className = 'bad';
         li.textContent = `Error loading uptime data: ${err.message}`;
         ul.appendChild(li);
+      }
+
+      // Load latest briefing text
+      try {
+        const res3 = await fetch(baseURL + 'latest.txt');
+        if (!res3.ok) throw new Error(`HTTP ${res3.status}`);
+        const text = await res3.text();
+        document.getElementById('latest-briefing').textContent = text.trim();
+      } catch (err) {
+        console.error('Failed to load latest briefing:', err);
+        const pre = document.getElementById('latest-briefing');
+        pre.classList.add('bad');
+        pre.textContent = `Error loading latest briefing: ${err.message}`;
       }
     });
   </script>


### PR DESCRIPTION
## Summary
- document system architecture
- enhance README with repository overview
- show latest briefing on the dashboard

## Testing
- `python -m py_compile generate_latest.py generate_weather.py test_feeds.py`

------
https://chatgpt.com/codex/tasks/task_e_688d23e3c6d0832284726e04acbe8b27