### PR TITLE
Fix missing OpenAI API key in workflows

### DIFF
--- a/.github/workflows/update-latest.yml
+++ b/.github/workflows/update-latest.yml
@@ -33,6 +33,8 @@ jobs:
 
       # 4. Run the generator
       - name: Generate latest.txt
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: python generate_latest.py
 
       # 5. Commit & push results

--- a/news_pipeline.yml
+++ b/news_pipeline.yml
@@ -43,6 +43,8 @@ jobs:
           message: 'chore: update health.json'
 
       - name: Generate latest briefing
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: python generate_latest.py
 
       - name: Commit updated latest.txt


### PR DESCRIPTION
## Summary
- expose the `OPENAI_API_KEY` secret to workflow steps that call `generate_latest.py`

## Testing
- `python -m py_compile generate_latest.py`
- ❌ `pip install pyyaml requests` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685dd1661af88322916399faa3bc68da