### PR TITLE
Add standalone State of Democracy Tracker form

### DIFF
--- a/state-of-democracy-tracker-form/.gitignore
+++ b/state-of-democracy-tracker-form/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.DS_Store
+.env

--- a/state-of-democracy-tracker-form/LICENSE
+++ b/state-of-democracy-tracker-form/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 State of Democracy Tracker contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/state-of-democracy-tracker-form/README.md
+++ b/state-of-democracy-tracker-form/README.md
@@ -1,0 +1,32 @@
+# State of Democracy Tracker Form
+
+A single-page HTML form for logging pro- or anti-democratic actions. Submissions are sent as JSON to a configurable webhook.
+
+## Edit the Webhook URL
+1. Open `submit.html` in a text editor.
+2. Replace `YOUR_WEBHOOK_OR_ENDPOINT_HERE` with your endpoint.
+3. Save and redeploy.
+
+## Deploy
+### GitHub Pages
+1. Commit and push this folder to a repository.
+2. In GitHub settings, enable **Pages** and select the branch and `/` root.
+3. The form will be served at `https://<username>.github.io/<repository>/submit.html`.
+
+### Vercel
+1. Create a new Vercel project from your repository.
+2. Deploy using default static site settings.
+
+## Add Additional Fields
+1. In `submit.html`, add new `<label>` and input elements inside the `<form>`.
+2. The JavaScript automatically serializes form fields, so the new field will be included in the JSON payload.
+
+## Development
+Run a local server to test:
+```sh
+npx serve .
+```
+Visit `http://localhost:3000/submit.html` and submit the form.
+
+## License
+MIT. See `LICENSE` for full text.

--- a/state-of-democracy-tracker-form/submit.html
+++ b/state-of-democracy-tracker-form/submit.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>State of Democracy Tracker – Admin Log</title>
+<style>
+body{font-family:sans-serif;background:#f4f4f4;padding:20px;max-width:600px;margin:auto}
+form{background:#fff;padding:20px;border-radius:8px;box-shadow:0 0 8px rgba(0,0,0,.1)}
+input,select,textarea{width:100%;padding:10px;margin:10px 0 20px;border-radius:5px;border:1px solid #ccc}
+button{background:#06c;color:#fff;padding:10px 15px;border:0;border-radius:5px;cursor:pointer}
+button:hover{background:#04a}
+</style>
+</head>
+<body>
+<h1>🗳️ State of Democracy Tracker – Admin Entry</h1>
+<form id="democracyForm">
+<label>Date:<input type="date" name="date" required></label>
+<label>Branch:
+<select name="branch" required>
+<option value="">Select...</option>
+<option>Executive</option>
+<option>Legislative</option>
+<option>Judicial</option>
+<option>State/Local</option>
+</select>
+</label>
+<label>Action / Event Title:<input type="text" name="action" required></label>
+<label>Source / Publisher:<input type="text" name="source" required></label>
+<label>Link to Source:<input type="url" name="url"></label>
+<label>Description / Notes:<textarea name="notes" rows="4" required></textarea></label>
+<button type="submit">Submit Entry</button>
+</form>
+<script>
+const endpoint="YOUR_WEBHOOK_OR_ENDPOINT_HERE";
+document.getElementById("democracyForm").addEventListener("submit",async e=>{
+e.preventDefault();
+const data=Object.fromEntries(new FormData(e.target).entries());
+try{
+const res=await fetch(endpoint,{method:"POST",headers:{"Content-Type":"application/json"},body:JSON.stringify(data)});
+if(res.ok){alert("Entry submitted successfully.");e.target.reset();}else{alert("Submission failed.");}
+}catch(err){alert("Network error.");}
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Package optimized `submit.html` with minimal inline styles and JS
- Add README with deployment and customization instructions
- Include MIT license and .gitignore

## Testing
- `curl -X POST ... http://localhost:8080` (`{"ok":true}`)
- `npx --yes htmlhint state-of-democracy-tracker-form/submit.html` (fails: 403 Forbidden)


------
https://chatgpt.com/codex/tasks/task_e_68913b77724483229a58635c70a38c1b