### PR TITLE
Add PATH reference architecture page and link from dashboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,8 @@
 </head>
 <body>
   <h1>RSS Feed Health Dashboard</h1>
+  <p><a href="path-reference-architecture.html">Open PATH Reference Architecture page</a></p>
+
   <p>Showing status for the last five days (hover for details).</p>
   <table id="health-table">
     <thead>

--- a/path-reference-architecture.html
+++ b/path-reference-architecture.html
@@ -1,0 +1,219 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>PATH — Reference Architecture (EA-Grade)</title>
+<style>
+  :root {
+    --teal-900:   #2F6F73;
+    --teal-700:   #3D8589;
+    --teal-600:   #5E9EA3;
+    --teal-200:   #CDE3E5;
+    --teal-100:   #E5F2F3;
+    --ai-green:   #A6CE39;
+    --ai-soft:    #D6E87A;
+    --gov-grey:   #8A8FA3;
+    --gov-light:  #F2F3F5;
+    --bg:         #F5F7F7;
+    --panel:      #E6E8E9;
+    --txt:        #4A4A4A;
+    --txt2:       #6D6E71;
+    --txt3:       #9A9B9D;
+    --amber:      #C8790A;
+    --amber-bg:   #FEF3E2;
+    --amber-bdr:  #F0BC6E;
+    --runtime-dk: #142F31;
+    --runtime-bg: #1E4E52;
+    --uc-clr:     #5E9EA3;
+    --pa-clr:     #7B68B0;
+    --pb-clr:     #B04E4E;
+    --white:      #ffffff;
+  }
+  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+  body { font-family: 'Calibri', 'Arial', sans-serif; background: #D4D8D9; color: var(--txt); font-size: 13px; line-height: 1.4; padding: 24px; display: flex; justify-content: center; }
+  .canvas { width: 1200px; background: var(--bg); box-shadow: 0 6px 32px rgba(0,0,0,0.15); }
+  .hdr { background: var(--teal-900); padding: 20px 28px 15px; display: flex; justify-content: space-between; align-items: flex-end; }
+  .hdr h1 { font-size: 21px; font-weight: 700; color: #fff; line-height: 1.2; }
+  .hdr-sub { font-size: 11px; color: #9ECFD2; margin-top: 5px; font-style: italic; }
+  .hdr-right { text-align: right; display: flex; flex-direction: column; gap: 5px; align-items: flex-end; }
+  .pill-ea { background: var(--ai-green); color: #243300; font-size: 9px; font-weight: 800; padding: 3px 10px; letter-spacing: .12em; text-transform: uppercase; }
+  .pill-proto { background: rgba(255,255,255,.12); color: #9ECFD2; font-size: 9px; font-weight: 700; padding: 3px 10px; letter-spacing: .1em; text-transform: uppercase; border: 1px solid rgba(255,255,255,.2); }
+  .hdr-class { font-size: 10px; color: #7EB8BC; }
+  .body { display: flex; }
+  .main { flex: 1; display: flex; flex-direction: column; }
+  .ent-zone { background: #2A3D4F; padding: 12px 24px; display: flex; gap: 24px; align-items: stretch; }
+  .ent-zone-label { writing-mode: vertical-rl; text-orientation: mixed; transform: rotate(180deg); font-size: 9px; font-weight: 800; text-transform: uppercase; letter-spacing: .14em; color: #7E9DB5; flex-shrink: 0; display: flex; align-items: center; margin-right: 4px; }
+  .ent-cols { flex: 1; display: flex; gap: 10px; }
+  .ent-group { flex: 1; background: rgba(255,255,255,.06); border: 1px solid rgba(255,255,255,.12); border-radius: 4px; padding: 10px 14px; }
+  .ent-group-hdr { font-size: 9px; font-weight: 800; text-transform: uppercase; letter-spacing: .12em; color: #7E9DB5; margin-bottom: 8px; padding-bottom: 5px; border-bottom: 1px solid rgba(255,255,255,.1); }
+  .ent-body-row { display: flex; gap: 8px; flex-wrap: wrap; }
+  .ent-item { background: rgba(255,255,255,.08); border: 1px solid rgba(255,255,255,.15); border-radius: 3px; padding: 6px 10px; }
+  .ent-item-title { font-size: 11px; font-weight: 700; color: #C4D8E2; margin-bottom: 2px; }
+  .ent-item-desc  { font-size: 10px; color: #7E9DB5; }
+  .boundary { display: flex; align-items: center; background: var(--bg); padding: 0 24px; position: relative; }
+  .boundary-inner { flex: 1; display: flex; align-items: center; border-top: 2px dashed #A0A8AA; position: relative; padding: 5px 0; }
+  .b-label-left { position: absolute; left: 0; background: #2A3D4F; color: #9ECFD2; font-size: 9px; font-weight: 800; text-transform: uppercase; letter-spacing: .12em; padding: 2px 8px; top: -9px; }
+  .b-label-right { position: absolute; right: 0; background: var(--teal-900); color: #CDE3E5; font-size: 9px; font-weight: 800; text-transform: uppercase; letter-spacing: .12em; padding: 2px 8px; top: -9px; }
+  .path-zone { display: flex; flex-direction: column; }
+  .layer { padding: 14px 24px; border-bottom: 1px solid #D0D4D5; }
+  .eyebrow { font-size: 9px; font-weight: 800; text-transform: uppercase; letter-spacing: .14em; margin-bottom: 11px; display: flex; align-items: center; gap: 10px; }
+  .erow { flex: 1; height: 1px; }
+  .lyr-clients { background: var(--teal-100); }
+  .lyr-clients .eyebrow { color: var(--teal-900); }
+  .lyr-clients .erow { background: var(--teal-600); opacity: .3; }
+  .client-row { display: flex; gap: 10px; }
+  .client-card { flex: 1; background: var(--white); border-radius: 4px; padding: 11px 13px; border: 1.5px solid #C5CACC; }
+  .cc-active { border-color: var(--ai-green); border-left-width: 4px; }
+  .cc-pilot  { border-color: var(--teal-900); border-left-width: 4px; }
+  .cc-future { border-style: dashed; border-color: #BCC0C2; opacity: .6; }
+  .cc-name   { font-size: 13px; font-weight: 700; color: var(--teal-900); margin-bottom: 4px; }
+  .state-tag { display: inline-block; font-size: 9px; font-weight: 700; text-transform: uppercase; letter-spacing: .1em; padding: 2px 7px; border-radius: 2px; margin-bottom: 5px; }
+  .t-active { background: var(--ai-green); color: #243300; }
+  .t-pilot  { background: var(--teal-900); color: #fff; }
+  .t-future { background: var(--panel); color: var(--txt2); }
+  .cc-desc  { font-size: 10px; color: var(--txt2); }
+  .cc-datarow { display: flex; gap: 5px; margin-top: 7px; flex-wrap: wrap; }
+  .data-badge { font-size: 9px; font-weight: 700; padding: 2px 6px; border-radius: 2px; border: 1px solid; text-transform: uppercase; letter-spacing: .07em; }
+  .db-uc   { color: var(--uc-clr); border-color: var(--uc-clr); background: #EEF6F7; }
+  .db-pa   { color: var(--pa-clr); border-color: var(--pa-clr); background: #F3F0FB; }
+  .db-pb   { color: var(--pb-clr); border-color: var(--pb-clr); background: #FBEAEA; }
+  .conn { display: flex; align-items: center; justify-content: center; padding: 4px 0; background: var(--bg); gap: 8px; }
+  .conn-line { flex: 1; height: 1px; background: var(--teal-200); max-width: 180px; }
+  .conn-lbl { font-size: 9px; text-transform: uppercase; letter-spacing: .14em; color: var(--txt3); }
+  .conn-arr { width: 0; height: 0; border-left: 5px solid transparent; border-right: 5px solid transparent; border-top: 7px solid var(--teal-200); }
+  .lyr-intake .eyebrow { color: var(--teal-700); }
+  .lyr-intake .erow { background: var(--teal-600); opacity: .25; }
+  .gateway-shell { background: var(--white); border: 2px solid var(--teal-700); border-radius: 5px; overflow: hidden; }
+  .gateway-top { background: var(--teal-700); padding: 8px 16px; }
+  .gateway-top-title { font-size: 12px; font-weight: 800; color: #fff; }
+  .gateway-top-sub { font-size: 10px; color: #B5D8DA; font-style: italic; }
+  .gateway-steps { display: flex; border-top: 1px solid #E0E5E6; }
+  .gw-step { flex: 1; padding: 11px 13px; border-right: 1px solid #E0E5E6; }
+  .gw-step:last-child { border-right: none; }
+  .gw-num { font-size: 11px; font-weight: 800; color: var(--teal-600); margin-bottom: 3px; }
+  .gw-title { font-size: 11px; font-weight: 700; color: var(--teal-900); margin-bottom: 3px; }
+  .gw-desc { font-size: 10px; color: var(--txt2); }
+  .gw-triggers { margin-top: 7px; display: flex; flex-direction: column; gap: 2px; }
+  .gw-trigger { font-size: 9px; color: var(--gov-grey); }
+  .gw-trigger::before { content: "→ "; color: var(--teal-600); }
+  .lyr-data { background: #F8F4FF; border-top: 2px solid var(--pa-clr); border-bottom: 1px solid #D8D4E8; }
+  .lyr-data .eyebrow { color: var(--pa-clr); }
+  .lyr-data .erow { background: var(--pa-clr); opacity: .3; }
+  .data-shell { display: flex; gap: 10px; align-items: stretch; }
+  .data-class-col { flex: 1; background: var(--white); border-radius: 4px; border: 1.5px solid; padding: 11px 13px; }
+  .dc-uc { border-color: var(--uc-clr); } .dc-pa { border-color: var(--pa-clr); } .dc-pb { border-color: var(--pb-clr); }
+  .dc-label { font-size: 10px; font-weight: 800; text-transform: uppercase; letter-spacing: .1em; margin-bottom: 6px; padding-bottom: 5px; border-bottom: 1px solid; display: flex; justify-content: space-between; align-items: center; }
+  .dc-label-uc { color: var(--uc-clr); border-color: var(--uc-clr); } .dc-label-pa { color: var(--pa-clr); border-color: var(--pa-clr); } .dc-label-pb { color: var(--pb-clr); border-color: var(--pb-clr); }
+  .dc-desc,.dc-patterns{font-size:10px;color:var(--txt2)}
+  .dc-p { font-size: 9px; color: var(--txt2); }
+  .dc-p::before { content: "✓ "; }
+  .dc-p.blocked { color: #BBA0A0; }
+  .dc-p.blocked::before { content: "✗ "; color: var(--pb-clr); }
+  .ato-overlay { background: var(--amber-bg); border: 1.5px solid var(--amber-bdr); border-radius: 4px; padding: 10px 13px; min-width: 160px; }
+  .ato-overlay-title { font-size: 11px; font-weight: 700; color: var(--amber); margin-bottom: 4px; }
+  .ato-overlay-desc { font-size: 10px; color: #8B6020; line-height: 1.4; }
+  .lyr-runtime { background: var(--runtime-bg); padding: 0; border-bottom: 3px solid #0D2224; }
+  .rt-hdr { background: var(--runtime-dk); padding: 10px 24px; display: flex; align-items: center; gap: 14px; }
+  .rt-title { font-size: 15px; font-weight: 700; color: #fff; }
+  .rt-sub { font-size: 11px; color: #6EADB1; font-style: italic; }
+  .rt-pill { margin-left: auto; background: var(--ai-green); color: #243300; font-size: 9px; font-weight: 800; padding: 3px 10px; text-transform: uppercase; }
+  .rt-body { padding: 13px 24px 17px; }
+  .rt-eyebrow { font-size: 9px; font-weight: 800; text-transform: uppercase; letter-spacing: .14em; color: #5A9BA0; display: flex; align-items: center; gap: 10px; margin-bottom: 11px; }
+  .rt-rule { flex: 1; height: 1px; background: #2E6468; }
+  .pattern-row { display: flex; gap: 10px; }
+  .pat-card { flex: 1; background: rgba(255,255,255,.07); border: 1px solid rgba(255,255,255,.15); border-radius: 5px; padding: 12px 13px; }
+  .pat-card.ai-sig { background: rgba(166,206,57,.10); border-color: var(--ai-green); border-left-width: 3px; }
+  .pat-card.alt-pat { background: rgba(255,255,255,.04); border-style: dashed; border-color: rgba(255,255,255,.2); opacity: .75; }
+  .pat-num { font-size: 9px; font-weight: 800; letter-spacing: .1em; text-transform: uppercase; color: var(--ai-soft); }
+  .pat-cap { font-size: 11px; font-weight: 700; color: rgba(255,255,255,.55); }
+  .pat-name { font-size: 13px; font-weight: 700; color: #fff; }
+  .pat-tech,.pat-note{font-size:10px;color:rgba(255,255,255,.6)} .pat-note{font-size:9px;color:rgba(255,255,255,.38);font-style:italic}
+  .pat-scope{margin-top:4px;display:flex;gap:4px;flex-wrap:wrap}
+  .ps-badge{font-size:8px;font-weight:700;padding:2px 5px;border-radius:2px;text-transform:uppercase;border:1px solid rgba(255,255,255,.25)}
+  .ps-uc{color:#A0D4D8;border-color:#A0D4D8}.ps-pa{color:#C4B8E8;border-color:#C4B8E8}
+  .lyr-ctrl { background: var(--gov-light); border-top: 2px solid var(--gov-grey); }
+  .lyr-ctrl .eyebrow{color:var(--gov-grey)} .lyr-ctrl .erow{background:var(--gov-grey);opacity:.3}
+  .ctrl-shell { background: var(--white); border: 1.5px solid var(--gov-grey); border-radius: 5px; overflow: hidden; }
+  .ctrl-top { background: var(--gov-grey); padding: 7px 16px; display: flex; align-items: center; gap: 12px; }
+  .ctrl-top-title{font-size:11px;font-weight:800;color:#fff;text-transform:uppercase;letter-spacing:.07em}
+  .ctrl-top-sub{font-size:10px;color:rgba(255,255,255,.65);font-style:italic}
+  .ctrl-row{display:flex}.ctrl-item{flex:1;padding:11px 13px;border-right:1px solid #E0E1E6}.ctrl-item:last-child{border-right:none}
+  .ci-title{font-size:11px;font-weight:700;color:var(--gov-grey);text-transform:uppercase;letter-spacing:.07em;margin-bottom:4px}
+  .ci-desc{font-size:10px;color:var(--txt2);line-height:1.45}
+  .gap-chip,.ato-chip{display:inline-block;margin-top:6px;background:var(--amber-bg);color:var(--amber);border:1px solid var(--amber-bdr);font-size:9px;font-weight:700;padding:2px 7px;text-transform:uppercase}
+  .lyr-infra { background: var(--teal-100); }
+  .lyr-infra .eyebrow{color:var(--teal-900)} .lyr-infra .erow{background:var(--teal-600);opacity:.3}
+  .infra-row{display:flex;gap:10px}.infra-card{flex:1;background:var(--white);border-radius:4px;padding:10px 12px;border:1px solid var(--teal-200)}
+  .ic-title{font-size:11px;font-weight:700;color:var(--teal-900);margin-bottom:3px}.ic-desc{font-size:10px;color:var(--txt2)}
+  .gov-col { width: 152px; background: #ECEDEF; border-left: 1px solid #D0D4D5; display: flex; flex-direction: column; }
+  .gc-hdr { background: var(--gov-grey); padding: 8px 10px; font-size: 9px; font-weight: 800; text-transform: uppercase; letter-spacing: .12em; color: #fff; text-align: center; }
+  .gc-sub { background: #DDE0E4; padding: 5px 10px; font-size: 9px; color: var(--txt3); text-align: center; font-style: italic; border-bottom: 1px solid #CDD0D4; }
+  .gc-body { flex: 1; padding: 10px 10px 8px; display: flex; flex-direction: column; gap: 7px; }
+  .gc-ann { padding: 7px 9px; background: var(--white); border-left: 2px solid var(--gov-grey); }
+  .gc-ann-title { font-size: 10px; font-weight: 700; color: var(--gov-grey); margin-bottom: 2px; }
+  .gc-ann-desc,.gc-principle{font-size:9px;color:var(--txt3);line-height:1.4}
+  .gc-principle{margin-top:auto;padding:8px;background:var(--teal-100);border-top:1px solid var(--teal-200);color:var(--teal-900);font-style:italic;text-align:center}
+  .legend { background: var(--panel); border-top: 1px solid #D0D4D5; padding: 8px 24px; display: flex; align-items: center; gap: 20px; flex-wrap: wrap; }
+  .legend-lbl { font-size: 9px; font-weight: 800; text-transform: uppercase; letter-spacing: .1em; color: var(--txt2); flex-shrink: 0; padding-right: 14px; border-right: 1px solid #C5CACC; }
+  .legend-group { display: flex; gap: 14px; flex-wrap: wrap; align-items: center; }
+  .li { display: flex; align-items: center; gap: 5px; font-size: 10px; color: var(--txt2); }
+  .sw { width: 22px; height: 11px; border-radius: 2px; flex-shrink: 0; }
+  .sw-active { background: var(--ai-green); } .sw-pilot{background:var(--teal-900)} .sw-future{background:transparent;border:1.5px dashed #9A9B9D}
+  .sw-gap{background:var(--amber-bg);border:1px solid var(--amber-bdr)} .sw-uc{background:#EEF6F7;border:1.5px solid var(--uc-clr)} .sw-pa{background:#F3F0FB;border:1.5px solid var(--pa-clr)} .sw-pb{background:#FBEAEA;border:1.5px solid var(--pb-clr)}
+  .legend-sep { width: 1px; height: 18px; background: #C5CACC; }
+  .gaps-bar { background: var(--amber-bg); border-top: 2px solid var(--amber-bdr); padding: 9px 24px; display: flex; align-items: center; }
+  .gb-lbl { font-size: 9px; font-weight: 800; color: var(--amber); text-transform: uppercase; letter-spacing: .12em; min-width: 90px; padding-right: 14px; border-right: 1px solid var(--amber-bdr); margin-right: 14px; }
+  .gb-items { display: flex; gap: 8px; flex-wrap: wrap; }
+  .gb-chip { background: #fff; border: 1px solid var(--amber-bdr); color: var(--amber); font-size: 10px; font-weight: 600; padding: 3px 10px; border-radius: 2px; }
+  .gb-chip::before { content: "⚠ "; font-size: 9px; }
+  .footer { background: #E4E7E7; border-top: 1px solid #D0D4D5; padding: 7px 24px; display: flex; justify-content: space-between; align-items: center; }
+  .ft-note { font-size: 10px; color: var(--txt3); font-style: italic; }
+  .ft-class { font-size: 10px; font-weight: 700; color: var(--txt2); text-transform: uppercase; letter-spacing: .06em; }
+</style>
+</head>
+<body>
+<div class="canvas" role="main" aria-label="PATH Reference Architecture — EA Grade">
+  <div class="hdr">
+    <div>
+      <h1>PATH — Reference Architecture</h1>
+      <div class="hdr-sub">AI Runtime / Execution Layer &nbsp;|&nbsp; Health Canada Digital Transformation Branch &nbsp;|&nbsp; April 2026</div>
+    </div>
+    <div class="hdr-right">
+      <div class="pill-ea">EA-Grade</div>
+      <div class="pill-proto">Pre-Prototype</div>
+      <div class="hdr-class">Unclassified / Non classifié</div>
+    </div>
+  </div>
+  <div class="body">
+    <div class="main">
+      <div class="ent-zone" aria-label="Enterprise Governance Zone — Decision Authority and Standards">
+        <div class="ent-zone-label" aria-hidden="true">Enterprise Governance</div>
+        <div class="ent-cols">
+          <div class="ent-group"><div class="ent-group-hdr">Decision Authority — Governance defined outside the runtime</div><div class="ent-body-row"><div class="ent-item"><div class="ent-item-title">OCDO</div><div class="ent-item-desc">Policy owner. AI Use Case Inventory. Sets enterprise AI direction.</div></div><div class="ent-item"><div class="ent-item-title">ARB</div><div class="ent-item-desc">Architecture gate. PATH alignment required before alternatives.</div></div><div class="ent-item"><div class="ent-item-title">DTB Leadership</div><div class="ent-item-desc">Aaron. Delivery oversight. Leadership visibility for Shafa.</div></div></div></div>
+          <div class="ent-group"><div class="ent-group-hdr">Standards and Assurance — Architecture, security, and compliance standards</div><div class="ent-body-row"><div class="ent-item"><div class="ent-item-title">EA / TPO</div><div class="ent-item-desc">Architecture standards. PATH documentation. IT Plan alignment.</div></div><div class="ent-item"><div class="ent-item-title">Security</div><div class="ent-item-desc">SA&amp;A ownership. ATO coordination. Purview integration (emerging).</div></div><div class="ent-item"><div class="ent-item-title">Privacy</div><div class="ent-item-desc">PIA triggers. Generative AI data handling. Protected B compliance.</div></div></div></div>
+        </div>
+      </div>
+      <div class="boundary"><div class="boundary-inner"><div class="b-label-left">Enterprise Responsibility</div><div class="b-label-right">PATH Service Delivery (DTB)</div></div></div>
+      <div class="path-zone">
+        <div class="layer lyr-clients"><div class="eyebrow">Client / Consumer<div class="erow"></div>Project Responsibility</div><div class="client-row"><div class="client-card cc-active"><div class="cc-name">CDO / Data Science</div><span class="state-tag t-active">Customer 1 — Active</span><div class="cc-desc">Internal data science team. First validated PATH consumer. Analytics and exploratory AI workloads.</div><div class="cc-datarow"><span class="data-badge db-uc">Unclassified</span><span class="data-badge db-pa">Protected A</span></div></div><div class="client-card cc-pilot"><div class="cc-name">PMRA / PDA</div><span class="state-tag t-pilot">Customer 2 — Active Pilot</span><div class="cc-desc">LLM over text in Active Lifecycle tool. Power Apps Premium UI. Narrow, low-risk, defensible.</div><div class="cc-datarow"><span class="data-badge db-uc">Unclassified</span></div></div><div class="client-card cc-future"><div class="cc-name">Future HC Branches</div><span class="state-tag t-future">Pending Intake Model</span><div class="cc-desc">Onboarding model validated through PMRA pilot before broader DTB rollout.</div><div class="cc-datarow"><span class="data-badge db-uc">Unclassified</span><span class="data-badge db-pa">Protected A</span><span class="data-badge db-pb">Protected B</span></div></div></div></div>
+        <div class="conn"><div class="conn-line"></div><div class="conn-arr"></div><div class="conn-lbl">Governed Intake</div><div class="conn-arr"></div><div class="conn-line"></div></div>
+        <div class="layer lyr-intake"><div class="eyebrow">Intake Control Gateway<div class="erow"></div>Classification confirmed here. Architecture routing determined here.</div><div class="gateway-shell"><div class="gateway-top"><div><div class="gateway-top-title">Intake Control Gateway</div><div class="gateway-top-sub">This is not a workflow — it is an architecture and governance entry point.</div></div></div><div class="gateway-steps"><div class="gw-step"><div class="gw-num">Gate 1</div><div class="gw-title">Intake Submission</div><div class="gw-desc">Client submits requirements and constraints.</div><div class="gw-triggers"><div class="gw-trigger">JIRA intake ticket opened</div><div class="gw-trigger">Data classification declared</div><div class="gw-trigger">Use case scope confirmed</div></div></div><div class="gw-step"><div class="gw-num">Gate 2</div><div class="gw-title">Pattern Assessment</div><div class="gw-desc">Match need to execution pattern.</div><div class="gw-triggers"><div class="gw-trigger">Evaluate ATO-approved first</div><div class="gw-trigger">Route to Fabric / Power Platform if applicable</div><div class="gw-trigger">Foundry only if justified</div></div></div><div class="gw-step"><div class="gw-num">Gate 3</div><div class="gw-title">Governance Gate</div><div class="gw-desc">AIA, PIA, SA&amp;A scope confirmed before provisioning.</div><div class="gw-triggers"><div class="gw-trigger">AIA applicability confirmed</div><div class="gw-trigger">PIA trigger assessed</div><div class="gw-trigger">ARB referral if required</div></div></div><div class="gw-step"><div class="gw-num">Gate 4</div><div class="gw-title">Environment Provisioning</div><div class="gw-desc">Provision per approved pattern. Cross-functional coordination.</div><div class="gw-triggers"><div class="gw-trigger">Cloud, security, EA, client aligned</div><div class="gw-trigger">FinOps envelope defined</div><div class="gw-trigger">Audit baseline established</div></div></div></div></div></div>
+        <div class="conn"><div class="conn-line"></div><div class="conn-arr"></div><div class="conn-lbl">Classification Enforced</div><div class="conn-arr"></div><div class="conn-line"></div></div>
+        <div class="layer lyr-data"><div class="eyebrow">Data Classification and Governance<div class="erow"></div>Determined at intake. Enforced at runtime. Controls which patterns are available.</div><div class="data-shell"><div class="data-class-col dc-uc"><div class="dc-label dc-label-uc">Unclassified<span class="data-badge db-uc">Available Now</span></div><div class="dc-desc">Non-sensitive operational data. Current scope for PMRA pilot and CDO initial workloads.</div><div class="dc-patterns"><div class="dc-pattern-label">Supported patterns:</div><div class="dc-p">VM-Based Exploration</div><div class="dc-p">Containerized Scaling</div><div class="dc-p">AI Foundry (per-client)</div><div class="dc-p">Fabric / Power Platform</div></div></div><div class="data-class-col dc-pa"><div class="dc-label dc-label-pa">Protected A<span class="data-badge db-pa">Limited</span></div><div class="dc-desc">Low-sensitivity personal or operational data. Requires confirmed SA&amp;A and PIA trigger assessment.</div><div class="dc-patterns"><div class="dc-pattern-label">Supported patterns:</div><div class="dc-p">Containerized Scaling</div><div class="dc-p">AI Foundry (per-client, with controls)</div><div class="dc-p blocked">VM-Based Exploration (not recommended)</div></div></div><div class="data-class-col dc-pb"><div class="dc-label dc-label-pb">Protected B<span class="data-badge db-pb">Blocked — ATO Required</span></div><div class="dc-desc">Sensitive personal data. Required for broader HC program delivery. All patterns blocked pending ATO resolution.</div><div class="dc-patterns"><div class="dc-pattern-label">Pattern availability:</div><div class="dc-p blocked">VM-Based Exploration — blocked</div><div class="dc-p blocked">Containerized Scaling — blocked</div><div class="dc-p blocked">AI Foundry — blocked</div><div class="dc-p blocked">Fabric / Power Platform — blocked</div></div></div><div class="ato-overlay"><div class="ato-overlay-title">Data Governance Controls</div><div class="ato-overlay-desc"><strong>Microsoft Purview</strong> — Under evaluation. Potential to reduce repeated SA&amp;A burden. Not yet operationalized.<br><br><strong>FAIR Principles</strong> — Required for all AI inputs. Data quality is the primary AI delivery risk.</div></div></div></div>
+        <div class="conn"><div class="conn-line"></div><div class="conn-arr"></div><div class="conn-lbl">Execution</div><div class="conn-arr"></div><div class="conn-line"></div></div>
+        <div class="lyr-runtime"><div class="rt-hdr"><div><div class="rt-title">PATH — AI Runtime / Execution Layer</div><div class="rt-sub">Governance enforced at runtime. Not a sandbox. Not a model host. The primary enterprise AI control point.</div></div><div class="rt-pill">Runtime Enforcement</div></div><div class="rt-body"><div class="rt-eyebrow">Current Service Catalog — Validated through pilot delivery<div class="rt-rule"></div></div><div class="pattern-row"><div class="pat-card"><div class="pat-num">Pattern 1</div><div class="pat-cap">Exploration</div><div class="pat-name">VM-Based Exploration</div><div class="pat-tech">Azure Virtual Machines</div><div class="pat-scope"><span class="ps-badge ps-uc">Unclassified</span></div><div class="pat-note">Early-stage data science. Lowest governance overhead. Not recommended for Protected A+.</div></div><div class="pat-card"><div class="pat-num">Pattern 2</div><div class="pat-cap">Scalable Workload</div><div class="pat-name">Containerized Scaling</div><div class="pat-tech">Application Containers</div><div class="pat-scope"><span class="ps-badge ps-uc">Unclassified</span><span class="ps-badge ps-pa">Protected A</span></div><div class="pat-note">Reproducible. Production-capable with controls. Scales under defined governance.</div></div><div class="pat-card ai-sig"><div class="pat-num" style="color:var(--ai-green);">Pattern 3 — AI Signal</div><div class="pat-cap" style="color:var(--ai-soft);">Managed AI</div><div class="pat-name">AI Foundry</div><div class="pat-tech">Azure AI Foundry — per-client instance</div><div class="pat-scope"><span class="ps-badge ps-uc">Unclassified</span><span class="ps-badge ps-pa">Protected A (with controls)</span></div><div class="pat-note">Per-client isolation. Shared-enterprise model not yet viable (FinOps constraint).</div></div><div class="pat-card alt-pat"><div class="pat-num">Alternate</div><div class="pat-cap">Enterprise-Integrated</div><div class="pat-name">Fabric / Power Platform</div><div class="pat-tech">Microsoft Fabric &nbsp;|&nbsp; Power Platform / Copilot API</div><div class="pat-scope"><span class="ps-badge ps-uc">Unclassified</span></div><div class="pat-note">Leverage ATO-approved environments. Pattern matched to need, not assumed.</div></div></div></div></div>
+        <div class="conn"><div class="conn-line"></div><div class="conn-arr"></div><div class="conn-lbl">Enforcement</div><div class="conn-arr"></div><div class="conn-line"></div></div>
+        <div class="layer lyr-ctrl"><div class="eyebrow">Runtime Control Plane<div class="erow"></div>Enforcement inside PATH — distinct from enterprise governance bodies above the boundary</div><div class="ctrl-shell"><div class="ctrl-top"><div class="ctrl-top-title">Enforcement Layer</div><div class="ctrl-top-sub">Governance defined outside (OCDO, ARB). Enforced here, at runtime.</div></div><div class="ctrl-row"><div class="ctrl-item"><div class="ci-title">Responsible AI Gate</div><div class="ci-desc">Multi-stakeholder sign-off before production. Security, privacy, EA, data science, audit.</div><div class="gap-chip">Emerging</div></div><div class="ctrl-item"><div class="ci-title">Audit and Traceability</div><div class="ci-desc">Model used, prompts issued, outputs produced. External defensibility for regulated workloads (PMRA).</div></div><div class="ctrl-item"><div class="ci-title">AIA / PIA / SA&amp;A</div><div class="ci-desc">AIA confirmed at intake. PIA required for generative AI touching personal data. SA&amp;A internally owned.</div></div><div class="ctrl-item"><div class="ci-title">FinOps and Cost Control</div><div class="ci-desc">Per-client billing isolation. Chargeback model in design. Shared-instance not yet viable.</div><div class="gap-chip">Model TBD</div></div></div></div></div>
+        <div class="conn"><div class="conn-line"></div><div class="conn-arr"></div><div class="conn-lbl">Infrastructure</div><div class="conn-arr"></div><div class="conn-line"></div></div>
+        <div class="layer lyr-infra"><div class="eyebrow">Infrastructure Foundation<div class="erow"></div></div><div class="infra-row"><div class="infra-card"><div class="ic-title">Azure Landing Zone (HC)</div><div class="ic-desc">Primary cloud. Canadian data residency mandatory. Distinct from PHAC HAIL.</div><div class="ato-chip">ATO Pending</div></div><div class="infra-card"><div class="ic-title">Identity and Access</div><div class="ic-desc">Microsoft Entra ID. Secure Gateway 2 with OIDC / MFA for external access (future).</div></div><div class="infra-card"><div class="ic-title">Data Governance</div><div class="ic-desc">Microsoft Purview under evaluation. Reduce repeated SA&amp;A burden if implemented. Not yet operational.</div><div class="ato-chip">Design Phase</div></div><div class="infra-card"><div class="ic-title">AI-Ops / Operating Model</div><div class="ic-desc">Platform ownership and lifecycle management not yet formally assigned. Delivery via JIRA.</div><div class="ato-chip">Ownership TBD</div></div></div></div>
+        <div class="legend"><div class="legend-lbl">State</div><div class="legend-group"><div class="li"><div class="sw sw-active"></div>Active</div><div class="li"><div class="sw sw-pilot"></div>Active Pilot</div><div class="li"><div class="sw sw-future"></div>Future / Emerging</div><div class="li"><div class="sw sw-gap"></div>Gap / Unresolved</div></div><div class="legend-sep"></div><div class="legend-lbl">Classification</div><div class="legend-group"><div class="li"><div class="sw sw-uc"></div>Unclassified</div><div class="li"><div class="sw sw-pa"></div>Protected A</div><div class="li"><div class="sw sw-pb"></div>Protected B (blocked)</div></div></div>
+        <div class="gaps-bar"><div class="gb-lbl">Active Gaps</div><div class="gb-items"><div class="gb-chip">ATO — blocks Protected B production</div><div class="gb-chip">FinOps / chargeback model undefined</div><div class="gb-chip">AI-Ops ownership unassigned</div><div class="gb-chip">Responsible AI governance emerging</div><div class="gb-chip">PATH definition not centrally documented</div></div></div>
+        <div class="footer"><div class="ft-note">EA/TPO interpretation — not citeable GC policy. Architecture reflects April 2026 directional agreement, not approved design. PATH is pre-prototype.</div><div class="ft-class">Unclassified / Non classifié</div></div>
+      </div>
+    </div>
+    <div class="gov-col" role="complementary" aria-label="Governance annotations"><div class="gc-hdr">Governance</div><div class="gc-sub">See enterprise zone above for decision authority</div><div class="gc-body"><div class="gc-ann"><div class="gc-ann-title">Ownership Shift</div><div class="gc-ann-desc">Delivery responsibility moved from CDO to DTB platform teams. Santa coordinates working-level execution.</div></div><div class="gc-ann"><div class="gc-ann-title">Santa</div><div class="gc-ann-desc">Working-level coordination. Cadence, JIRA tracking, intake / onboarding with Jason's team.</div></div><div class="gc-ann"><div class="gc-ann-title">Jason</div><div class="gc-ann-desc">Platform and cloud. Foundry deployment model. Primary FinOps constraint owner.</div></div><div class="gc-ann"><div class="gc-ann-title">Kirk</div><div class="gc-ann-desc">Security and data governance. Purview evaluation. M365 / ATO renewal alignment.</div></div><div class="gc-ann"><div class="gc-ann-title">Ali</div><div class="gc-ann-desc">Architecture evaluation. Foundry as pilot vs long-term pattern. Reusable architecture extraction.</div></div><div class="gc-ann"><div class="gc-ann-title">Chad</div><div class="gc-ann-desc">EA strategic framing. PATH documentation. IT Plan positioning.</div></div><div class="gc-principle">Governance defined outside the runtime.<br>Enforced inside it.</div></div></div>
+  </div>
+</div>
+</body>
+</html>

--- a/path-reference-architecture.html
+++ b/path-reference-architecture.html
@@ -31,7 +31,7 @@
     --white:      #ffffff;
   }
   *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
-  body { font-family: 'Calibri', 'Arial', sans-serif; background: #D4D8D9; color: var(--txt); font-size: 13px; line-height: 1.4; padding: 24px; display: flex; justify-content: center; }
+  body { font-family: 'Calibri', 'Arial', sans-serif; background: #D4D8D9; color: var(--txt); font-size: 13px; line-height: 1.4; padding: 24px; display: flex; justify-content: center; overflow-x: auto; }
   .canvas { width: 1200px; background: var(--bg); box-shadow: 0 6px 32px rgba(0,0,0,0.15); }
   .hdr { background: var(--teal-900); padding: 20px 28px 15px; display: flex; justify-content: space-between; align-items: flex-end; }
   .hdr h1 { font-size: 21px; font-weight: 700; color: #fff; line-height: 1.2; }
@@ -170,6 +170,11 @@
   .footer { background: #E4E7E7; border-top: 1px solid #D0D4D5; padding: 7px 24px; display: flex; justify-content: space-between; align-items: center; }
   .ft-note { font-size: 10px; color: var(--txt3); font-style: italic; }
   .ft-class { font-size: 10px; font-weight: 700; color: var(--txt2); text-transform: uppercase; letter-spacing: .06em; }
+  @media (max-width: 1260px) {
+    body { justify-content: flex-start; }
+    .canvas { min-width: 1200px; }
+  }
+
 </style>
 </head>
 <body>


### PR DESCRIPTION
### Motivation
- Provide the PATH reference architecture as a standalone, shareable web page using the supplied HTML/CSS so stakeholders can view the design in a browser.  
- Make the new architecture page discoverable from the existing RSS Feed Health Dashboard so it is easy to access from the current site.

### Description
- Add a new static file `path-reference-architecture.html` containing the provided PATH markup and consolidated CSS to render the architecture diagram as a web page.  
- Insert a direct link into `index.html` so the dashboard includes a link to `path-reference-architecture.html`.  
- The change is static HTML/CSS only and does not modify the dashboard's data fetching or runtime JavaScript logic.  
- Files were created/updated in the project tree so the page is available alongside the existing site files.

### Testing
- Ran a small Python HTML parsing snippet (`html.parser`) against both `index.html` and `path-reference-architecture.html` to verify they parse without errors, and it completed successfully.  
- Performed a local smoke inspection of `index.html` to confirm the new link is present and that `path-reference-architecture.html` exists and contains the expected markup, and the inspection succeeded.  
- No browser rendering/screenshot tests were run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0eacdfdd48322810dce389f52df13)