### PR TITLE
Add Architecture Fitness Agent and Knowledge Graph Explorer UI; update Admin Log page

### DIFF
--- a/architecture-fitness-agent.html
+++ b/architecture-fitness-agent.html
@@ -1,0 +1,820 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Architecture Fitness Agent</title>
+  <style>
+    @import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@300;400;500;600&family=JetBrains+Mono:wght@400;500&display=swap');
+
+    :root {
+      --bg: #060d1a;
+      --bg2: #080f1e;
+      --panel: #0a1628;
+      --border: #0d2040;
+      --text: #e1f0ff;
+      --text-dim: #4a7fa5;
+      --text-muted: #1a3352;
+      --accent: #0078d4;
+      --ok: #107c10;
+      --warn: #835b00;
+      --bad: #c50f1f;
+    }
+
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    html, body { height: 100%; }
+    body {
+      background: var(--bg);
+      color: var(--text);
+      font-family: 'IBM Plex Sans', sans-serif;
+    }
+
+    .hidden { display: none !important; }
+    .app { min-height: 100vh; display: flex; flex-direction: column; }
+
+    .setup-wrap {
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 24px;
+    }
+    .setup-shell { width: 100%; max-width: 520px; }
+    .setup-head { text-align: center; margin-bottom: 30px; }
+    .icon {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 52px; height: 52px;
+      border-radius: 12px;
+      background: linear-gradient(135deg, #0078d4, #50e6ff);
+      margin-bottom: 14px;
+      box-shadow: 0 0 32px rgba(0,120,212,0.4);
+      font-size: 22px;
+      color: #fff;
+    }
+    .title { color: var(--text); font-size: 20px; font-weight: 600; }
+    .subtitle { color: #2a5a7a; font-size: 11px; font-family: 'JetBrains Mono', monospace; margin-top: 4px; }
+
+    .card {
+      background: var(--panel);
+      border: 1px solid #1a3352;
+      border-radius: 12px;
+      padding: 24px 22px;
+      box-shadow: 0 20px 60px rgba(0,0,0,0.5);
+    }
+
+    .field { margin-bottom: 14px; }
+    .label {
+      display: block;
+      font-size: 10px;
+      font-weight: 700;
+      color: var(--text-dim);
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      margin-bottom: 5px;
+      font-family: 'JetBrains Mono', monospace;
+    }
+    .input, .textarea {
+      width: 100%;
+      padding: 9px 12px;
+      background: var(--bg);
+      border: 1px solid #1a3352;
+      border-radius: 6px;
+      color: var(--text);
+      font-size: 13px;
+      outline: none;
+      font-family: 'JetBrains Mono', monospace;
+    }
+    .input:focus, .textarea:focus { border-color: var(--accent); }
+    .helper { margin-top: 4px; font-size: 10px; color: var(--text-muted); font-family: 'JetBrains Mono', monospace; }
+    .divider {
+      border-top: 1px solid var(--border);
+      margin: 16px 0 14px;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      color: var(--text-muted);
+      font-size: 10px;
+      font-family: 'JetBrains Mono', monospace;
+    }
+    .divider::after { content: ''; flex: 1; border-top: 1px solid var(--border); }
+
+    .btn {
+      border: none;
+      border-radius: 8px;
+      cursor: pointer;
+      font-size: 13px;
+      font-weight: 600;
+      font-family: 'IBM Plex Sans', sans-serif;
+      transition: opacity 0.15s;
+    }
+    .btn:hover { opacity: 0.9; }
+    .btn-primary {
+      width: 100%;
+      padding: 12px;
+      background: linear-gradient(135deg, #0078d4, #106ebe);
+      color: #fff;
+      box-shadow: 0 4px 20px rgba(0,120,212,0.35);
+    }
+    .btn-primary:disabled {
+      background: #0a1628;
+      color: #1a3352;
+      box-shadow: none;
+      cursor: not-allowed;
+    }
+    .token-wrap { position: relative; }
+    .token-toggle {
+      position: absolute;
+      right: 10px;
+      top: 50%;
+      transform: translateY(-50%);
+      border: none;
+      background: transparent;
+      color: var(--text-dim);
+      cursor: pointer;
+    }
+
+    .main { min-height: 100vh; display: flex; flex-direction: column; }
+    .topbar {
+      background: var(--bg2);
+      border-bottom: 1px solid var(--border);
+      padding: 0 20px;
+      height: 44px;
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      flex-shrink: 0;
+    }
+    .status-dot { width: 6px; height: 6px; border-radius: 50%; background: #1a3352; }
+    .status-dot.on { background: #50e6ff; box-shadow: 0 0 6px #50e6ff; }
+    .mono { font-family: 'JetBrains Mono', monospace; }
+    .tiny { font-size: 10px; }
+
+    .topbar-actions { margin-left: auto; display: flex; gap: 8px; }
+    .btn-outline {
+      background: transparent;
+      border: 1px solid var(--border);
+      border-radius: 5px;
+      color: var(--text-dim);
+      font-size: 10px;
+      padding: 4px 10px;
+      cursor: pointer;
+      text-decoration: none;
+      display: inline-flex;
+      align-items: center;
+      font-family: 'JetBrains Mono', monospace;
+    }
+
+    .ref-panel {
+      background: var(--bg2);
+      border-bottom: 1px solid var(--border);
+      padding: 12px 20px;
+    }
+    .ref-pre {
+      color: var(--text-dim);
+      font-size: 10px;
+      font-family: 'JetBrains Mono', monospace;
+      line-height: 1.6;
+      white-space: pre-wrap;
+      max-height: 220px;
+      overflow-y: auto;
+    }
+
+    .workspace {
+      display: flex;
+      flex: 1;
+      min-height: 0;
+      overflow: hidden;
+    }
+    .left {
+      width: 340px;
+      flex-shrink: 0;
+      border-right: 1px solid var(--border);
+      display: flex;
+      flex-direction: column;
+      gap: 14px;
+      padding: 16px;
+      overflow-y: auto;
+    }
+    .right { flex: 1; overflow-y: auto; padding: 24px 28px; }
+
+    .label-2 {
+      font-size: 10px;
+      font-weight: 700;
+      color: var(--text-dim);
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      margin-bottom: 8px;
+      font-family: 'JetBrains Mono', monospace;
+    }
+
+    .example-btn {
+      display: block;
+      width: 100%;
+      text-align: left;
+      background: transparent;
+      border: 1px solid var(--border);
+      border-radius: 5px;
+      color: #2a5a7a;
+      font-size: 10px;
+      padding: 6px 10px;
+      cursor: pointer;
+      margin-bottom: 4px;
+      line-height: 1.4;
+    }
+    .example-btn:hover { border-color: var(--accent); color: var(--text-dim); }
+
+    .error {
+      background: rgba(197,15,31,0.12);
+      border: 1px solid rgba(197,15,31,0.3);
+      border-radius: 6px;
+      padding: 8px 10px;
+      color: #ef9a9a;
+      font-size: 11px;
+      font-family: 'JetBrains Mono', monospace;
+    }
+
+    .result-card {
+      background: var(--panel);
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      padding: 18px;
+      margin-bottom: 14px;
+    }
+
+    .result-head {
+      display: flex;
+      align-items: center;
+      gap: 18px;
+    }
+
+    .score-gauge {
+      width: 90px;
+      height: 90px;
+      border-radius: 50%;
+      border: 6px solid #0d2040;
+      display: grid;
+      place-items: center;
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 24px;
+      font-weight: 700;
+    }
+
+    .badge {
+      display: inline-block;
+      border-radius: 4px;
+      padding: 4px 12px;
+      font-size: 12px;
+      font-weight: 800;
+      letter-spacing: 0.12em;
+      font-family: 'JetBrains Mono', monospace;
+      border: 2px solid;
+    }
+
+    .grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 12px;
+    }
+    .dim-title {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      margin-bottom: 8px;
+      font-size: 11px;
+    }
+    .bar { height: 4px; background: #0d2040; border-radius: 2px; overflow: hidden; margin-bottom: 10px; }
+    .fill { height: 100%; border-radius: 2px; }
+
+    .list-item { display: flex; gap: 8px; margin-bottom: 5px; font-size: 12px; color: #b0cce0; }
+
+    @media (max-width: 980px) {
+      .workspace { flex-direction: column; }
+      .left { width: 100%; border-right: none; border-bottom: 1px solid var(--border); }
+      .grid { grid-template-columns: 1fr; }
+    }
+  </style>
+</head>
+<body>
+<div class="app" id="app">
+  <div class="setup-wrap" id="setupScreen">
+    <div class="setup-shell">
+      <div class="setup-head">
+        <div class="icon">◎</div>
+        <div class="title">Architecture Fitness Agent</div>
+        <div class="subtitle">HC/PHAC EA · Azure MCP 2.0 · PATH/HAIL Reference Arch</div>
+      </div>
+
+      <div class="card">
+        <div class="field">
+          <label class="label" for="apiKey">Anthropic API Key *</label>
+          <input class="input" id="apiKey" type="password" placeholder="sk-ant-..." autocomplete="off">
+        </div>
+
+        <div class="divider">AZURE MCP 2.0 — OPTIONAL</div>
+
+        <div class="field">
+          <label class="label" for="mcpUrl">Azure MCP Server URL</label>
+          <input class="input" id="mcpUrl" type="text" placeholder="https://your-azmcp.azurecontainerapps.io/mcp">
+          <p class="helper">Leave blank to run without live Azure queries.</p>
+        </div>
+
+        <div class="field">
+          <label class="label" for="mcpToken">Entra Bearer Token</label>
+          <div class="token-wrap">
+            <input class="input" id="mcpToken" type="password" placeholder="eyJ0eXAiOiJKV1Q...">
+            <button class="token-toggle" id="toggleToken" type="button">👁</button>
+          </div>
+          <p class="helper">az account get-access-token --resource 499b84ac-1321-427f-aa17-267ca6975798 -o tsv</p>
+        </div>
+
+        <button class="btn btn-primary" id="launchBtn" disabled>Launch Fitness Agent →</button>
+      </div>
+      <p class="helper" style="text-align:center; margin-top: 12px;">All credentials stay in browser session only.</p>
+    </div>
+  </div>
+
+  <div class="main hidden" id="mainScreen">
+    <div class="topbar">
+      <span style="color:#50e6ff;">◎</span>
+      <span style="font-size:13px; font-weight:600;">Architecture Fitness Agent</span>
+      <div style="display:flex; align-items:center; gap:6px; margin-left:8px;">
+        <span class="status-dot" id="mcpDot"></span>
+        <span class="mono tiny" id="mcpLabel">No MCP — diagram-only mode</span>
+      </div>
+      <div class="topbar-actions">
+        <button class="btn-outline" id="toggleRefBtn">View Reference Arch</button>
+        <a class="btn-outline" href="index.html">Knowledge Graph Explorer</a>
+        <a class="btn-outline" href="submit.html">Admin Log</a>
+        <button class="btn-outline" id="settingsBtn">Settings</button>
+      </div>
+    </div>
+
+    <div class="ref-panel hidden" id="refPanel">
+      <div style="position:relative;">
+        <textarea id="refInput" class="textarea hidden" rows="12" style="font-size:11px; line-height:1.6;"></textarea>
+        <pre id="refPre" class="ref-pre"></pre>
+        <button class="btn-outline" id="editRefBtn" style="position:absolute; right:0; top:0;">Edit</button>
+      </div>
+    </div>
+
+    <div class="workspace">
+      <div class="left">
+        <div>
+          <div class="label-2">Solution to Assess</div>
+          <textarea id="solutionInput" class="textarea" rows="11" style="line-height:1.6; font-family:'IBM Plex Sans', sans-serif;" placeholder="Describe a proposed solution, technology, or architectural decision."></textarea>
+        </div>
+
+        <div>
+          <div class="helper" style="margin-bottom:6px;">QUICK EXAMPLES</div>
+          <div id="examples"></div>
+        </div>
+
+        <div id="errorBox" class="error hidden"></div>
+
+        <button id="assessBtn" class="btn btn-primary" disabled>Rate Architecture Fit →</button>
+        <button id="newBtn" class="btn-outline hidden" style="justify-content:center;">New Assessment</button>
+      </div>
+
+      <div class="right" id="resultsWrap">
+        <div id="emptyState" style="height:100%; display:flex; align-items:center; justify-content:center; text-align:center;">
+          <div>
+            <div style="font-size:48px; margin-bottom:16px; opacity:0.1;">◎</div>
+            <div style="color:#1a3352; font-size:13px; max-width:380px; line-height:1.7;">
+              Describe a proposed solution on the left. The agent will rate it against your HC/PHAC reference architecture and principles.
+            </div>
+          </div>
+        </div>
+        <div id="loadingState" class="hidden">
+          <div class="result-card">Evaluating architecture fitness…</div>
+        </div>
+        <div id="resultState" class="hidden"></div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script>
+  const DEFAULT_REFERENCE = `HC/PHAC AI Platform Reference Architecture — PATH/HAIL
+
+PLATFORM PRINCIPLES:
+
+1. Protected B by default — all workloads assume PBMM classification unless explicitly scoped lower
+2. Azure Canada East primary, Canada Central DR — no data leaves Canadian sovereign boundary
+3. Entra ID as sole identity provider — no local accounts, service principals require justification
+4. Private endpoints mandatory for all PaaS — no public endpoints on data or AI services
+5. AI Runtime Layer enforces policy at inference time — no direct model access bypassing controls
+6. AIA required before any automated decision system reaches production
+7. GC Guardrails compliance is non-negotiable — 12 guardrails must be green before any workload goes live
+8. MCP as integration standard — new integrations use MCP before custom API patterns
+9. Azure MCP Server 2.0 self-hosted inside PATH boundary — OBO auth via Entra ID
+10. Observability first — all components emit to centralized Log Analytics workspace
+
+REFERENCE ARCHITECTURE LAYERS:
+
+- L1 AI Runtime (HAIL): Policy enforcement, model gateway, audit logging, rate limiting
+- L2 Orchestration: Multi-agent coordination, Semantic Kernel, prompt management
+- L3 Data Platform: Azure Data Factory, Fabric, protected data stores, RAG pipeline
+- L4 Integration: Azure API Management, Service Bus, MCP server layer, Graph API
+- L5 Foundation: Landing zone, hub-spoke networking, Defender for Cloud, Sentinel
+
+APPROVED SERVICES (Protected B validated by CCCS):
+Azure OpenAI Service (Canada East), Azure AI Foundry, Azure API Management,
+Azure Container Apps, Azure Kubernetes Service, Azure Key Vault, Azure Monitor,
+Microsoft Defender for Cloud, Azure Policy, Log Analytics, Azure Data Factory,
+Microsoft Fabric, Azure Service Bus, Azure Private DNS, Azure Firewall Premium
+
+ANTI-PATTERNS TO FLAG:
+
+- Public endpoints on any data service
+- Bypassing AI Runtime Layer for direct model calls
+- Storing secrets outside Key Vault
+- Automated decisions without AIA documentation
+- Cross-region data flows without explicit approval
+- Using unapproved CSPs or regions
+- Shadow AI tools not governed through PATH`;
+
+  const DIMENSIONS = [
+    { id: 'pbmm', label: 'PBMM / GC Compliance', color: '#D83B01', icon: '⬡' },
+    { id: 'security', label: 'Security & Zero Trust', color: '#C50F1F', icon: '◈' },
+    { id: 'architecture', label: 'Reference Architecture Fit', color: '#0078D4', icon: '◎' },
+    { id: 'ai_governance', label: 'AI Governance', color: '#038387', icon: '◐' },
+    { id: 'integration', label: 'Integration Pattern', color: '#7719AA', icon: '⊞' },
+    { id: 'operability', label: 'Operability & Observability', color: '#107C10', icon: '◆' }
+  ];
+
+  const examples = [
+    'Use Azure OpenAI via the PATH AI Runtime Layer for a new chatbot',
+    'Store Protected B data in SharePoint Online',
+    'Deploy a Python ML model directly to Azure Functions with no API gateway',
+    'Use AWS Bedrock for AI inference',
+    'Implement MCP for integration with ADO using Azure MCP Server 2.0'
+  ];
+
+  const state = {
+    apiKey: '',
+    mcpUrl: '',
+    mcpToken: '',
+    refArch: DEFAULT_REFERENCE,
+    editingRef: false,
+    solution: '',
+    result: null,
+    loading: false,
+    chatHistory: []
+  };
+
+  function systemPrompt(refArch) {
+    return `You are the HC/PHAC Enterprise Architecture Fitness Agent — an expert system that evaluates proposed solutions, technologies, and architectural decisions against the organization’s reference architecture and principles.
+
+${refArch}
+
+YOUR ROLE:
+When given a solution description, technology proposal, or architectural question:
+
+1. If Azure MCP tools are available, PROACTIVELY use them to query the live Azure environment for relevant context (existing resources, policies, compliance posture, Advisor recommendations)
+2. Rate the solution across six dimensions on a 0-100 scale
+3. Provide evidence-based reasoning for each rating
+4. Flag specific anti-patterns or compliance risks
+5. Give a clear ADOPT / TRIAL / ASSESS / HOLD recommendation (using the Technology Radar model)
+6. Suggest modifications to improve fit
+
+RATING SCALE:
+90-100: Excellent fit, aligns fully with principles
+70-89: Good fit, minor gaps addressable
+50-69: Partial fit, significant modifications needed
+30-49: Poor fit, fundamental conflicts with principles
+0-29: Not recommended, violates core principles
+
+OUTPUT FORMAT — respond with a JSON object only, no markdown, no preamble:
+{
+  "recommendation": "ADOPT|TRIAL|ASSESS|HOLD",
+  "recommendation_rationale": "2-3 sentence summary",
+  "overall_score": 0-100,
+  "dimensions": {
+    "pbmm": { "score": 0-100, "rationale": "...", "gaps": ["..."], "strengths": ["..."] },
+    "security": { "score": 0-100, "rationale": "...", "gaps": ["..."], "strengths": ["..."] },
+    "architecture": { "score": 0-100, "rationale": "...", "gaps": ["..."], "strengths": ["..."] },
+    "ai_governance": { "score": 0-100, "rationale": "...", "gaps": ["..."], "strengths": ["..."] },
+    "integration": { "score": 0-100, "rationale": "...", "gaps": ["..."], "strengths": ["..."] },
+    "operability": { "score": 0-100, "rationale": "...", "gaps": ["..."], "strengths": ["..."] }
+  },
+  "anti_patterns_detected": ["..."],
+  "live_environment_findings": ["..."],
+  "modifications": ["..."],
+  "mcp_tools_used": ["..."]
+}`;
+  }
+
+  const el = {
+    setupScreen: document.getElementById('setupScreen'),
+    mainScreen: document.getElementById('mainScreen'),
+    apiKey: document.getElementById('apiKey'),
+    mcpUrl: document.getElementById('mcpUrl'),
+    mcpToken: document.getElementById('mcpToken'),
+    toggleToken: document.getElementById('toggleToken'),
+    launchBtn: document.getElementById('launchBtn'),
+    mcpDot: document.getElementById('mcpDot'),
+    mcpLabel: document.getElementById('mcpLabel'),
+    toggleRefBtn: document.getElementById('toggleRefBtn'),
+    settingsBtn: document.getElementById('settingsBtn'),
+    refPanel: document.getElementById('refPanel'),
+    refInput: document.getElementById('refInput'),
+    refPre: document.getElementById('refPre'),
+    editRefBtn: document.getElementById('editRefBtn'),
+    solutionInput: document.getElementById('solutionInput'),
+    examples: document.getElementById('examples'),
+    errorBox: document.getElementById('errorBox'),
+    assessBtn: document.getElementById('assessBtn'),
+    newBtn: document.getElementById('newBtn'),
+    emptyState: document.getElementById('emptyState'),
+    loadingState: document.getElementById('loadingState'),
+    resultState: document.getElementById('resultState')
+  };
+
+  function scoreColor(score) {
+    return score >= 70 ? '#107C10' : score >= 50 ? '#835B00' : '#C50F1F';
+  }
+
+  function badgeStyles(rec) {
+    const map = {
+      ADOPT: { bg: '#DFF6DD', text: '#107C10', border: '#107C10' },
+      TRIAL: { bg: '#EFF6FC', text: '#0078D4', border: '#0078D4' },
+      ASSESS: { bg: '#FFF4CE', text: '#835B00', border: '#835B00' },
+      HOLD: { bg: '#FDE7E9', text: '#C50F1F', border: '#C50F1F' }
+    };
+    return map[rec] || map.ASSESS;
+  }
+
+  function setError(msg = '') {
+    if (!msg) {
+      el.errorBox.classList.add('hidden');
+      el.errorBox.textContent = '';
+      return;
+    }
+    el.errorBox.classList.remove('hidden');
+    el.errorBox.textContent = msg;
+  }
+
+  function renderExamples() {
+    el.examples.textContent = '';
+    examples.forEach(text => {
+      const btn = document.createElement('button');
+      btn.className = 'example-btn';
+      btn.type = 'button';
+      btn.textContent = text;
+      btn.addEventListener('click', () => {
+        el.solutionInput.value = text;
+        state.solution = text;
+        refreshButtons();
+      });
+      el.examples.appendChild(btn);
+    });
+  }
+
+  function refreshButtons() {
+    state.apiKey = el.apiKey.value.trim();
+    state.mcpUrl = el.mcpUrl.value.trim();
+    state.mcpToken = el.mcpToken.value.trim();
+    state.solution = el.solutionInput.value;
+
+    el.launchBtn.disabled = !state.apiKey;
+    el.assessBtn.disabled = state.loading || !state.solution.trim();
+
+    el.mcpDot.classList.toggle('on', Boolean(state.mcpUrl));
+    el.mcpLabel.textContent = state.mcpUrl ? 'Azure MCP connected' : 'No MCP — diagram-only mode';
+    el.emptyState.querySelector('div div:last-child').textContent =
+      `Describe a proposed solution on the left. The agent will rate it against your HC/PHAC reference architecture and principles${state.mcpUrl ? ', querying your live Azure environment via MCP' : ''}.`;
+  }
+
+  function setView(main) {
+    el.setupScreen.classList.toggle('hidden', main);
+    el.mainScreen.classList.toggle('hidden', !main);
+  }
+
+  function renderReference() {
+    el.refInput.value = state.refArch;
+    el.refPre.textContent = state.refArch;
+    el.refInput.classList.toggle('hidden', !state.editingRef);
+    el.refPre.classList.toggle('hidden', state.editingRef);
+    el.editRefBtn.textContent = state.editingRef ? 'Save' : 'Edit';
+  }
+
+  function renderResult() {
+    if (!state.result) {
+      el.resultState.classList.add('hidden');
+      el.emptyState.classList.remove('hidden');
+      return;
+    }
+
+    const result = state.result;
+    const badge = badgeStyles(result.recommendation);
+    const overallColor = scoreColor(result.overall_score || 0);
+
+    const top = `
+      <div class="result-card result-head">
+        <div class="score-gauge" style="border-color:${overallColor}; color:${overallColor};">${result.overall_score ?? 0}</div>
+        <div style="flex:1;">
+          <div style="margin-bottom:8px; display:flex; align-items:center; gap:10px;">
+            <span class="badge" style="background:${badge.bg}; color:${badge.text}; border-color:${badge.border};">${result.recommendation || 'ASSESS'}</span>
+            <span class="mono tiny" style="color:#1a3352;">Technology Radar rating</span>
+          </div>
+          <div style="color:#b0cce0; font-size:13px; line-height:1.6;">${escapeHtml(result.recommendation_rationale || '')}</div>
+        </div>
+      </div>`;
+
+    const dims = DIMENSIONS.map(dim => {
+      const d = result.dimensions?.[dim.id];
+      if (!d) return '';
+      const color = scoreColor(Number(d.score || 0));
+      const gaps = (d.gaps || []).slice(0, 2).map(g => `<div class="list-item"><span style="color:#C50F1F;">✕</span><span>${escapeHtml(g)}</span></div>`).join('');
+      const strengths = (d.strengths || []).slice(0, 1).map(s => `<div class="list-item"><span style="color:#107C10;">✓</span><span>${escapeHtml(s)}</span></div>`).join('');
+      return `
+        <div class="result-card">
+          <div class="dim-title">
+            <span><span style="color:${dim.color}; margin-right:6px;">${dim.icon}</span>${dim.label}</span>
+            <strong style="color:${color}; font-family:'JetBrains Mono', monospace; font-size:16px;">${d.score ?? 0}</strong>
+          </div>
+          <div class="bar"><div class="fill" style="width:${Math.max(0, Math.min(100, Number(d.score || 0)))}%; background:${color};"></div></div>
+          <div style="color:#4a7fa5; font-size:11px; margin-bottom:8px; line-height:1.5;">${escapeHtml(d.rationale || '')}</div>
+          ${gaps}
+          ${strengths}
+        </div>`;
+    }).join('');
+
+    const anti = Array.isArray(result.anti_patterns_detected) && result.anti_patterns_detected.length
+      ? `<div class="result-card" style="background:rgba(197,15,31,0.08); border-color:rgba(197,15,31,0.25)">
+           <div class="mono" style="font-size:11px; font-weight:700; color:#ef9a9a; margin-bottom:8px;">⚠ Anti-Patterns Detected</div>
+           ${result.anti_patterns_detected.map(a => `<div class="list-item"><span style="color:#C50F1F;">✕</span><span style="color:#ef9a9a;">${escapeHtml(a)}</span></div>`).join('')}
+         </div>` : '';
+
+    const live = Array.isArray(result.live_environment_findings) && result.live_environment_findings.length && result.live_environment_findings[0] !== 'No MCP tools available'
+      ? `<div class="result-card" style="background:rgba(80,230,255,0.05); border-color:rgba(80,230,255,0.15)">
+           <div class="mono" style="font-size:11px; font-weight:700; color:#50e6ff; margin-bottom:8px;">◈ Live Azure Environment Findings</div>
+           ${result.live_environment_findings.map(f => `<div class="list-item"><span style="color:#4a7fa5;">◆</span><span>${escapeHtml(f)}</span></div>`).join('')}
+           ${Array.isArray(result.mcp_tools_used) && result.mcp_tools_used.length ? `<div class="mono tiny" style="color:#1a3352; margin-top:8px;">Tools used: ${result.mcp_tools_used.map(escapeHtml).join(', ')}</div>` : ''}
+         </div>` : '';
+
+    const mods = Array.isArray(result.modifications) && result.modifications.length
+      ? `<div class="result-card">
+           <div class="mono" style="font-size:11px; font-weight:700; color:#4a7fa5; margin-bottom:8px;">Recommended Modifications</div>
+           ${result.modifications.map((m, i) => `<div class="list-item"><span style="color:#0078D4; font-weight:700;">${i + 1}.</span><span>${escapeHtml(m)}</span></div>`).join('')}
+         </div>` : '';
+
+    el.resultState.innerHTML = `${top}<div class="grid">${dims}</div>${anti}${live}${mods}`;
+    el.resultState.classList.remove('hidden');
+    el.emptyState.classList.add('hidden');
+    el.newBtn.classList.remove('hidden');
+  }
+
+  function escapeHtml(str) {
+    return String(str)
+      .replaceAll('&', '&amp;')
+      .replaceAll('<', '&lt;')
+      .replaceAll('>', '&gt;')
+      .replaceAll('"', '&quot;')
+      .replaceAll("'", '&#39;');
+  }
+
+  async function runAssessment() {
+    const solution = el.solutionInput.value.trim();
+    if (!solution) {
+      setError('Describe the solution to assess.');
+      return;
+    }
+
+    setError('');
+    state.loading = true;
+    state.result = null;
+    refreshButtons();
+    el.resultState.classList.add('hidden');
+    el.emptyState.classList.add('hidden');
+    el.loadingState.classList.remove('hidden');
+
+    const userMsg = { role: 'user', content: solution };
+    const history = [...state.chatHistory, userMsg];
+
+    const mcpServers = state.mcpUrl ? [{
+      type: 'url',
+      url: state.mcpUrl,
+      name: 'azure-mcp',
+      ...(state.mcpToken ? { authorization_token: state.mcpToken } : {})
+    }] : [];
+
+    const body = {
+      model: 'claude-sonnet-4-20250514',
+      max_tokens: 2000,
+      system: systemPrompt(state.refArch),
+      messages: history,
+      ...(mcpServers.length ? { mcp_servers: mcpServers } : {})
+    };
+
+    const headers = {
+      'Content-Type': 'application/json',
+      'x-api-key': state.apiKey,
+      'anthropic-version': '2023-06-01',
+      'anthropic-dangerous-direct-browser-access': 'true',
+      ...(mcpServers.length ? { 'anthropic-beta': 'mcp-client-2025-11-20' } : {})
+    };
+
+    try {
+      const response = await fetch('https://api.anthropic.com/v1/messages', {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(body)
+      });
+      const data = await response.json();
+
+      if (data.error) {
+        setError(`API error: ${data.error.message}`);
+        return;
+      }
+
+      const textBlock = (data.content || []).find(b => b.type === 'text');
+      if (!textBlock) {
+        setError('No response received.');
+        return;
+      }
+
+      let parsed;
+      try {
+        const clean = textBlock.text.replace(/```json\n?|\n?```/g, '').trim();
+        parsed = JSON.parse(clean);
+      } catch {
+        setError('Could not parse rating response. Raw: ' + String(textBlock.text).slice(0, 220));
+        return;
+      }
+
+      state.result = parsed;
+      state.chatHistory = [...history, { role: 'assistant', content: textBlock.text }];
+      el.solutionInput.value = '';
+      refreshButtons();
+      renderResult();
+    } catch (err) {
+      setError(`Request failed: ${err.message}`);
+    } finally {
+      state.loading = false;
+      el.loadingState.classList.add('hidden');
+      if (!state.result) {
+        el.emptyState.classList.remove('hidden');
+      }
+      refreshButtons();
+    }
+  }
+
+  el.apiKey.addEventListener('input', refreshButtons);
+  el.mcpUrl.addEventListener('input', refreshButtons);
+  el.mcpToken.addEventListener('input', refreshButtons);
+  el.solutionInput.addEventListener('input', refreshButtons);
+
+  el.toggleToken.addEventListener('click', () => {
+    el.mcpToken.type = el.mcpToken.type === 'password' ? 'text' : 'password';
+    el.toggleToken.textContent = el.mcpToken.type === 'password' ? '👁' : '🙈';
+  });
+
+  el.launchBtn.addEventListener('click', () => {
+    state.apiKey = el.apiKey.value.trim();
+    if (!state.apiKey) return;
+    setView(true);
+    refreshButtons();
+  });
+
+  el.settingsBtn.addEventListener('click', () => {
+    setView(false);
+    state.result = null;
+    state.chatHistory = [];
+    el.resultState.classList.add('hidden');
+    el.emptyState.classList.remove('hidden');
+    el.newBtn.classList.add('hidden');
+  });
+
+  el.toggleRefBtn.addEventListener('click', () => {
+    el.refPanel.classList.toggle('hidden');
+    el.toggleRefBtn.textContent = el.refPanel.classList.contains('hidden') ? 'View Reference Arch' : 'Hide Reference Arch';
+  });
+
+  el.editRefBtn.addEventListener('click', () => {
+    if (state.editingRef) {
+      state.refArch = el.refInput.value;
+    }
+    state.editingRef = !state.editingRef;
+    renderReference();
+  });
+
+  el.assessBtn.addEventListener('click', runAssessment);
+  el.newBtn.addEventListener('click', () => {
+    state.result = null;
+    state.chatHistory = [];
+    el.solutionInput.value = '';
+    setError('');
+    renderResult();
+    refreshButtons();
+    el.newBtn.classList.add('hidden');
+  });
+
+  renderExamples();
+  renderReference();
+  refreshButtons();
+</script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,162 +1,842 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>RSS Feed Health Dashboard</title>
-  <style>
-    body { font-family: sans-serif; margin: 2rem; }
-    h1 {
-      display: inline-block;
-      padding: 0.35rem 0.8rem;
-      border-radius: 0.6rem;
-      color: #fff;
-      background: linear-gradient(120deg, #0a84ff, #5e5ce6, #30d158);
-      background-size: 220% 220%;
-      animation: gradient-shift 5s ease infinite;
-    }
-    table { width: 100%; border-collapse: collapse; margin-top: 1rem; }
-    th, td { border: 1px solid #ccc; padding: 0.5rem; text-align: left; }
-    th { background: #f0f0f0; }
-    .good { color: green; }
-    .warn { color: orange; }
-    .bad  { color: red; }
-    #uptime-list { margin-top: 1rem; list-style: none; padding: 0; }
-    #uptime-list li { margin-bottom: 0.5rem; }
-    #latest-briefing { white-space: pre-wrap; border: 1px solid #ccc; padding: 1rem; background: #f9f9f9; margin-top: 1rem; }
-    #latest-briefing.loading {
-      color: transparent;
-      background: linear-gradient(90deg, #f0f0f0 25%, #e0e0e0 37%, #f0f0f0 63%);
-      background-size: 400% 100%;
-      animation: shimmer 1.3s linear infinite;
-      min-height: 8rem;
-      user-select: none;
-    }
-    tr.data-row {
-      opacity: 0;
-      transform: translateY(10px);
-      animation: row-in 420ms ease forwards;
-    }
-    @keyframes shimmer {
-      0% { background-position: 100% 0; }
-      100% { background-position: -100% 0; }
-    }
-    @keyframes gradient-shift {
-      0% { background-position: 0% 50%; }
-      50% { background-position: 100% 50%; }
-      100% { background-position: 0% 50%; }
-    }
-    @keyframes row-in {
-      to {
-        opacity: 1;
-        transform: translateY(0);
-      }
-    }
-  </style>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>HC/PHAC Knowledge Graph Explorer</title>
+<style>
+@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@300;400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600&display=swap');
+
+:root {
+  --bg:         #07101e;
+  --bg2:        #0d1a2e;
+  --bg3:        #111f35;
+  --bg4:        #182840;
+  --border:     rgba(255,255,255,0.08);
+  --border-lt:  rgba(255,255,255,0.14);
+  --accent:     #2563eb;
+  --accent-lt:  #3b82f6;
+  --neo4j:      #018bff;
+  --neo4j-bg:   rgba(1,139,255,0.1);
+  --green:      #10b981;
+  --orange:     #f59e0b;
+  --text:       #e2e8f0;
+  --text-dim:   #64748b;
+  --text-mid:   #94a3b8;
+  --mono:       'IBM Plex Mono', monospace;
+  --sans:       'IBM Plex Sans', sans-serif;
+  --sidebar-w:  260px;
+}
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+
+html, body {
+  height: 100%;
+  background: var(--bg);
+  font-family: var(--sans);
+  color: var(--text);
+  overflow: hidden;
+}
+
+.shell { display: flex; height: 100vh; }
+
+.sidebar {
+  width: var(--sidebar-w);
+  flex-shrink: 0;
+  background: var(--bg2);
+  border-right: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.logo-bar { padding: 18px 16px 14px; border-bottom: 1px solid var(--border); flex-shrink: 0; }
+.logo-lockup { display: flex; align-items: center; gap: 10px; margin-bottom: 6px; }
+.logo-icon {
+  width: 32px; height: 32px;
+  background: linear-gradient(135deg, #018bff 0%, #8b5cf6 100%);
+  border-radius: 8px;
+  display: flex; align-items: center; justify-content: center;
+  font-size: 16px;
+  flex-shrink: 0;
+}
+.logo-name { font-size: 13px; font-weight: 700; color: var(--text); line-height: 1.2; }
+.logo-sub {
+  font-size: 9px;
+  font-family: var(--mono);
+  color: var(--text-dim);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.instance-cfg { padding: 10px 14px; border-bottom: 1px solid var(--border); flex-shrink: 0; }
+.cfg-label {
+  font-size: 9px;
+  font-family: var(--mono);
+  color: var(--text-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  margin-bottom: 5px;
+}
+.cfg-input {
+  width: 100%;
+  background: var(--bg3);
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  padding: 6px 9px;
+  font-size: 11px;
+  font-family: var(--mono);
+  color: var(--text);
+  outline: none;
+  margin-bottom: 5px;
+}
+.cfg-input:focus { border-color: var(--accent-lt); }
+.cfg-input::placeholder { color: var(--text-dim); }
+.cfg-row { display: flex; gap: 5px; }
+.cfg-row .cfg-input { margin-bottom: 0; }
+.connect-btn {
+  width: 100%;
+  background: var(--accent);
+  border: none;
+  border-radius: 5px;
+  padding: 7px;
+  font-size: 11px;
+  font-family: var(--mono);
+  font-weight: 600;
+  color: #fff;
+  cursor: pointer;
+  margin-top: 6px;
+  transition: opacity 0.15s;
+  letter-spacing: 0.03em;
+}
+.connect-btn:hover { opacity: 0.85; }
+.connect-btn:disabled { opacity: 0.6; cursor: wait; }
+
+.conn-status {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 10px;
+  font-family: var(--mono);
+  color: var(--text-dim);
+  margin-top: 6px;
+}
+.conn-dot {
+  width: 7px; height: 7px;
+  border-radius: 50%;
+  background: var(--text-dim);
+  flex-shrink: 0;
+}
+.conn-dot.live {
+  background: var(--green);
+  box-shadow: 0 0 5px var(--green);
+  animation: blink 2s infinite;
+}
+.conn-dot.err { background: #ef4444; box-shadow: 0 0 5px #ef4444; }
+@keyframes blink { 0%, 100% { opacity: 1; } 50% { opacity: 0.4; } }
+
+.graph-section { flex: 1; overflow-y: auto; padding: 10px; }
+.graph-section::-webkit-scrollbar { width: 3px; }
+.graph-section::-webkit-scrollbar-thumb { background: var(--border-lt); border-radius: 2px; }
+
+.section-hdr {
+  font-size: 9px;
+  font-family: var(--mono);
+  font-weight: 700;
+  color: var(--text-dim);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  padding: 8px 6px 6px;
+}
+
+.graph-card {
+  border-radius: 7px;
+  padding: 10px 11px;
+  margin-bottom: 4px;
+  cursor: pointer;
+  border: 1px solid transparent;
+  transition: all 0.15s;
+  position: relative;
+}
+.graph-card:hover { background: var(--bg3); border-color: var(--border); }
+.graph-card.active { background: var(--neo4j-bg); border-color: rgba(1,139,255,0.35); }
+.graph-card.active::before {
+  content: '';
+  position: absolute;
+  left: 0; top: 50%;
+  transform: translateY(-50%);
+  width: 3px; height: 60%;
+  background: var(--neo4j);
+  border-radius: 0 2px 2px 0;
+}
+
+.gc-top { display: flex; align-items: flex-start; gap: 8px; margin-bottom: 5px; }
+.gc-icon {
+  width: 26px; height: 26px;
+  border-radius: 5px;
+  display: flex; align-items: center; justify-content: center;
+  font-size: 13px;
+  flex-shrink: 0;
+  margin-top: 1px;
+}
+.gc-body { flex: 1; min-width: 0; }
+.gc-name {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text);
+  line-height: 1.2;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.gc-db { font-size: 9px; font-family: var(--mono); color: var(--text-dim); margin-top: 1px; }
+.graph-card.active .gc-db { color: var(--neo4j); }
+
+.gc-tags { display: flex; gap: 4px; flex-wrap: wrap; }
+.gc-tag {
+  font-size: 9px;
+  font-family: var(--mono);
+  padding: 1px 5px;
+  border-radius: 3px;
+  background: var(--bg4);
+  border: 1px solid var(--border);
+  color: var(--text-dim);
+}
+.graph-card.active .gc-tag { background: rgba(1,139,255,0.08); border-color: rgba(1,139,255,0.2); color: #7ec8fd; }
+
+.add-graph-btn {
+  width: 100%;
+  background: transparent;
+  border: 1px dashed var(--border-lt);
+  border-radius: 7px;
+  padding: 8px;
+  font-size: 11px;
+  font-family: var(--mono);
+  color: var(--text-dim);
+  cursor: pointer;
+  text-align: center;
+  margin-top: 4px;
+  transition: all 0.15s;
+}
+.add-graph-btn:hover { border-color: var(--accent-lt); color: var(--accent-lt); background: rgba(59,130,246,0.05); }
+
+.sidebar-footer { border-top: 1px solid var(--border); padding: 10px 14px; flex-shrink: 0; }
+.footer-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 10px;
+  font-family: var(--mono);
+  color: var(--text-dim);
+  margin-bottom: 4px;
+}
+.footer-row:last-child { margin-bottom: 0; }
+.footer-val { color: var(--text-mid); }
+.footer-links {
+  margin-top: 10px;
+  padding-top: 10px;
+  border-top: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.footer-link {
+  display: inline-block;
+  color: var(--text-mid);
+  text-decoration: none;
+  font-size: 10px;
+  font-family: var(--mono);
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  padding: 5px 7px;
+  transition: all 0.15s;
+}
+.footer-link:hover { color: var(--text); border-color: var(--border-lt); background: var(--bg3); }
+
+.content { flex: 1; display: flex; flex-direction: column; min-width: 0; }
+
+.top-bar {
+  height: 44px;
+  background: var(--bg2);
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  padding: 0 16px;
+  gap: 12px;
+  flex-shrink: 0;
+}
+.current-graph { display: flex; align-items: center; gap: 8px; }
+.cg-icon {
+  width: 22px; height: 22px;
+  border-radius: 4px;
+  display: flex; align-items: center; justify-content: center;
+  font-size: 11px;
+  flex-shrink: 0;
+}
+.cg-name { font-size: 13px; font-weight: 600; color: var(--text); }
+.cg-db-badge {
+  font-size: 10px;
+  font-family: var(--mono);
+  background: var(--neo4j-bg);
+  border: 1px solid rgba(1,139,255,0.3);
+  color: var(--neo4j);
+  padding: 2px 8px;
+  border-radius: 3px;
+}
+.bar-sep { flex: 1; }
+.bar-actions { display: flex; gap: 6px; align-items: center; }
+.bar-btn {
+  background: var(--bg3);
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  padding: 4px 10px;
+  font-size: 11px;
+  font-family: var(--mono);
+  color: var(--text-mid);
+  cursor: pointer;
+  transition: all 0.15s;
+}
+.bar-btn:hover { border-color: var(--border-lt); color: var(--text); }
+.bar-btn.neo4j { background: var(--neo4j-bg); border-color: rgba(1,139,255,0.35); color: var(--neo4j); }
+
+.iframe-wrapper { flex: 1; position: relative; background: var(--bg); }
+.neo4j-frame { width: 100%; height: 100%; border: none; display: block; }
+
+.placeholder {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  background: var(--bg);
+}
+.placeholder.hidden { display: none; }
+
+.ph-graphic { position: relative; width: 120px; height: 120px; }
+.ph-node {
+  position: absolute;
+  border-radius: 50%;
+  display: flex; align-items: center; justify-content: center;
+  font-size: 18px;
+  font-weight: 700;
+  box-shadow: 0 0 20px currentColor;
+  animation: float 3s ease-in-out infinite;
+}
+.ph-n1 { width: 52px; height: 52px; left: 34px; top: 34px; background: rgba(1,139,255,0.15); border: 2px solid #018bff; color: #018bff; animation-delay: 0s; }
+.ph-n2 { width: 36px; height: 36px; left: 0; top: 0; background: rgba(139,92,246,0.15); border: 2px solid #8b5cf6; color: #8b5cf6; animation-delay: 0.4s; }
+.ph-n3 { width: 32px; height: 32px; right: 0; top: 8px; background: rgba(16,185,129,0.15); border: 2px solid #10b981; color: #10b981; animation-delay: 0.8s; }
+.ph-n4 { width: 30px; height: 30px; left: 8px; bottom: 0; background: rgba(245,158,11,0.15); border: 2px solid #f59e0b; color: #f59e0b; animation-delay: 1.2s; }
+@keyframes float { 0%, 100% { transform: translateY(0); } 50% { transform: translateY(-4px); } }
+
+.ph-title { font-size: 18px; font-weight: 700; color: var(--text); text-align: center; }
+.ph-sub {
+  font-size: 12px;
+  font-family: var(--mono);
+  color: var(--text-dim);
+  text-align: center;
+  line-height: 1.8;
+  max-width: 360px;
+}
+.ph-cta {
+  background: var(--accent);
+  border: none;
+  border-radius: 7px;
+  padding: 10px 24px;
+  font-size: 13px;
+  font-weight: 600;
+  color: #fff;
+  cursor: pointer;
+  font-family: var(--sans);
+  transition: opacity 0.15s;
+}
+.ph-cta:hover { opacity: 0.85; }
+
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.7);
+  backdrop-filter: blur(4px);
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s;
+}
+.modal-overlay.open { opacity: 1; pointer-events: all; }
+.modal {
+  background: var(--bg2);
+  border: 1px solid var(--border-lt);
+  border-radius: 12px;
+  padding: 24px;
+  width: 380px;
+  box-shadow: 0 20px 60px rgba(0,0,0,0.5);
+}
+.modal-title {
+  font-size: 15px;
+  font-weight: 700;
+  color: var(--text);
+  margin-bottom: 18px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.modal-field { margin-bottom: 12px; }
+.modal-label {
+  font-size: 10px;
+  font-family: var(--mono);
+  color: var(--text-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin-bottom: 5px;
+}
+.modal-input {
+  width: 100%;
+  background: var(--bg3);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 8px 11px;
+  font-size: 12px;
+  font-family: var(--mono);
+  color: var(--text);
+  outline: none;
+}
+.modal-input:focus { border-color: var(--accent-lt); }
+.modal-input::placeholder { color: var(--text-dim); }
+.emoji-picker { display: flex; gap: 6px; flex-wrap: wrap; margin-top: 4px; }
+.emoji-opt {
+  width: 32px; height: 32px;
+  border-radius: 6px;
+  background: var(--bg3);
+  border: 1px solid var(--border);
+  display: flex; align-items: center; justify-content: center;
+  font-size: 16px;
+  cursor: pointer;
+  transition: all 0.1s;
+}
+.emoji-opt:hover, .emoji-opt.selected { border-color: var(--accent-lt); background: rgba(59,130,246,0.1); }
+.color-picker-row { display: flex; gap: 6px; margin-top: 4px; }
+.color-opt {
+  width: 22px; height: 22px;
+  border-radius: 50%;
+  cursor: pointer;
+  border: 2px solid transparent;
+  transition: border-color 0.1s;
+  flex-shrink: 0;
+}
+.color-opt:hover, .color-opt.selected { border-color: #fff; }
+.modal-actions { display: flex; gap: 8px; margin-top: 18px; }
+.modal-btn {
+  flex: 1;
+  padding: 9px;
+  border-radius: 7px;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  font-family: var(--sans);
+  border: none;
+  transition: opacity 0.15s;
+}
+.modal-btn-cancel { background: var(--bg3); border: 1px solid var(--border); color: var(--text-mid); }
+.modal-btn-add { background: var(--neo4j); color: #fff; }
+.modal-btn:hover { opacity: 0.85; }
+</style>
 </head>
 <body>
-  <h1>RSS Feed Health Dashboard</h1>
-  <p>Showing status for the last five days (hover for details).</p>
-  <table id="health-table">
-    <thead>
-      <tr><th>Date</th><th>Feed</th><th>Status</th></tr>
-    </thead>
-    <tbody></tbody>
-  </table>
+<div class="shell">
+  <div class="sidebar">
+    <div class="logo-bar">
+      <div class="logo-lockup">
+        <div class="logo-icon">🕸</div>
+        <div>
+          <div class="logo-name">Knowledge Graph Explorer</div>
+          <div class="logo-sub">HC/PHAC · EA Platform</div>
+        </div>
+      </div>
+    </div>
 
-  <h2>Canadian Feed Uptime (past 7 days)</h2>
-  <ul id="uptime-list"></ul>
+    <div class="instance-cfg">
+      <div class="cfg-label">Neo4j Instance</div>
+      <input class="cfg-input" id="instanceUrl" type="text" placeholder="http://localhost:7474" value="http://localhost:7474">
+      <div class="cfg-row">
+        <input class="cfg-input" id="instanceUser" type="text" placeholder="User" value="neo4j" style="flex:1">
+        <input class="cfg-input" id="instancePass" type="password" placeholder="Pass" style="flex:1">
+      </div>
+      <button class="connect-btn" id="connectBtn" onclick="connect()">Connect</button>
+      <div class="conn-status">
+        <div class="conn-dot" id="connDot"></div>
+        <span id="connLabel">Not connected</span>
+      </div>
+    </div>
 
-  <h2>Latest News Briefing</h2>
-  <pre id="latest-briefing">Loading latest briefing...</pre>
+    <div class="graph-section">
+      <div class="section-hdr">Knowledge Graphs</div>
+      <div id="graphList"></div>
+      <button class="add-graph-btn" onclick="openAddModal()">+ Add Graph / Database</button>
+    </div>
 
-  <script>
-    document.addEventListener('DOMContentLoaded', async () => {
-      const baseURL = 'https://jjuniper-dev.github.io/hc-news-briefing-feed.github.io/';
+    <div class="sidebar-footer">
+      <div class="footer-row"><span>Graphs</span><span class="footer-val" id="footerGraphCount">0</span></div>
+      <div class="footer-row"><span>Active DB</span><span class="footer-val" id="footerActiveDb">—</span></div>
+      <div class="footer-row"><span>Instance</span><span class="footer-val" id="footerInstance">localhost:7474</span></div>
+      <div class="footer-links">
+        <a class="footer-link" href="index.html">Knowledge Graph Explorer</a>
+        <a class="footer-link" href="architecture-fitness-agent.html">Architecture Fitness Agent</a>
+        <a class="footer-link" href="submit.html">Admin Log Entry</a>
+      </div>
+    </div>
+  </div>
 
-      const latestBriefingEl = document.getElementById('latest-briefing');
-      latestBriefingEl.classList.add('loading');
+  <div class="content">
+    <div class="top-bar">
+      <div class="current-graph" id="topBarGraph">
+        <div class="cg-icon" id="topBarIcon" style="background:rgba(1,139,255,0.1);">🕸</div>
+        <div class="cg-name" id="topBarName">No graph selected</div>
+      </div>
+      <span class="cg-db-badge" id="topBarDb" style="display:none"></span>
+      <div class="bar-sep"></div>
+      <div class="bar-actions">
+        <button class="bar-btn" onclick="reloadFrame()" title="Reload">↺ Reload</button>
+        <button class="bar-btn" onclick="openInTab()" title="Open in new tab">↗ Full Screen</button>
+        <button class="bar-btn neo4j" onclick="openNeo4jDirect()">Neo4j Browser ↗</button>
+      </div>
+    </div>
 
-      // Load health.json and populate health table
-      try {
-        const res = await fetch(baseURL + 'health.json');
-        if (!res.ok) throw new Error(`HTTP ${res.status}`);
-        const data = await res.json();
-        const tbody = document.querySelector('#health-table tbody');
-        let rowIndex = 0;
-        for (const [date, feeds] of Object.entries(data).slice(-5).reverse()) {
-          for (const [name, status] of Object.entries(feeds)) {
-            const tr = document.createElement('tr');
-            tr.className = 'data-row';
-            tr.style.animationDelay = `${Math.min(rowIndex * 45, 500)}ms`;
-            const cls = status.startsWith('ERROR') ? 'bad'
-                      : status === 'ZERO'      ? 'warn'
-                      : 'good';
-            tr.innerHTML = `
-              <td>${date}</td>
-              <td>${name}</td>
-              <td class="${cls}" title="${status}">${status}</td>
-            `;
-            tbody.appendChild(tr);
-            rowIndex++;
-          }
-        }
-      } catch (err) {
-        console.error('Failed to load health.json:', err);
-        const tbody = document.querySelector('#health-table tbody');
-        const tr = document.createElement('tr');
-        tr.innerHTML = `<td colspan="3" class="bad">Error loading data: ${err.message}</td>`;
-        tbody.appendChild(tr);
-      }
+    <div class="iframe-wrapper">
+      <div class="placeholder" id="placeholder">
+        <div class="ph-graphic">
+          <div class="ph-node ph-n1">N</div>
+          <div class="ph-node ph-n2">P</div>
+          <div class="ph-node ph-n3">H</div>
+          <div class="ph-node ph-n4">A</div>
+        </div>
+        <div class="ph-title">Knowledge Graph Explorer</div>
+        <div class="ph-sub">
+          Enter your Neo4j instance URL above and click Connect.<br>
+          Then select a graph from the sidebar to load it.
+        </div>
+        <button class="ph-cta" onclick="connect()">Connect to Neo4j</button>
+      </div>
 
-      // Load uptime.json and compute uptime percentages
-      try {
-        const res2 = await fetch(baseURL + 'uptime.json');
-        if (!res2.ok) throw new Error(`HTTP ${res2.status}`);
-        const records = await res2.json();
-        const total = records.length;
-        const success = {};
-        // Initialize counters
-        if (total > 0) {
-          Object.keys(records[0]).filter(k => k !== 'timestamp').forEach(feed => success[feed] = 0);
-        }
-        records.forEach(r => {
-          Object.entries(r).forEach(([feed, ok]) => {
-            if (feed === 'timestamp') return;
-            if (ok) success[feed]++;
-          });
-        });
-        const ul = document.getElementById('uptime-list');
-        Object.entries(success).forEach(([feed, count]) => {
-          const pct = total ? Math.round(count / total * 100) : 0;
-          const li = document.createElement('li');
-          li.textContent = `${feed}: ${pct}% (${count}/${total} pings OK)`;
-          ul.appendChild(li);
-        });
-      } catch (err) {
-        console.error('Failed to load uptime.json:', err);
-        const ul = document.getElementById('uptime-list');
-        const li = document.createElement('li');
-        li.className = 'bad';
-        li.textContent = `Error loading uptime data: ${err.message}`;
-        ul.appendChild(li);
-      }
+      <iframe id="neo4jFrame" class="neo4j-frame" style="display:none" allow="fullscreen" title="Neo4j Browser"></iframe>
+    </div>
+  </div>
+</div>
 
-      // Load latest briefing text
-      try {
-        const res3 = await fetch(baseURL + 'latest.txt');
-        if (!res3.ok) throw new Error(`HTTP ${res3.status}`);
-        const text = await res3.text();
-        latestBriefingEl.classList.remove('loading');
-        latestBriefingEl.textContent = text.trim();
-      } catch (err) {
-        console.error('Failed to load latest briefing:', err);
-        const pre = latestBriefingEl;
-        pre.classList.remove('loading');
-        pre.classList.add('bad');
-        pre.textContent = `Error loading latest briefing: ${err.message}`;
-      }
+<div class="modal-overlay" id="modalOverlay" onclick="closeModalIfBg(event)">
+  <div class="modal">
+    <div class="modal-title">🕸 Add Knowledge Graph</div>
+
+    <div class="modal-field">
+      <div class="modal-label">Display Name</div>
+      <input class="modal-input" id="newName" type="text" placeholder="e.g. PMRA Regulatory Graph">
+    </div>
+
+    <div class="modal-field">
+      <div class="modal-label">Neo4j Database Name</div>
+      <input class="modal-input" id="newDb" type="text" placeholder="e.g. pmra (default: neo4j)">
+    </div>
+
+    <div class="modal-field">
+      <div class="modal-label">Description</div>
+      <input class="modal-input" id="newDesc" type="text" placeholder="Short description of this graph">
+    </div>
+
+    <div class="modal-field">
+      <div class="modal-label">Tags (comma separated)</div>
+      <input class="modal-input" id="newTags" type="text" placeholder="e.g. regulatory, Protected B, PMRA">
+    </div>
+
+    <div class="modal-field">
+      <div class="modal-label">Icon</div>
+      <div class="emoji-picker" id="emojiPicker">
+        <div class="emoji-opt selected" data-emoji="🕸" onclick="pickEmoji(this)">🕸</div>
+        <div class="emoji-opt" data-emoji="🧬" onclick="pickEmoji(this)">🧬</div>
+        <div class="emoji-opt" data-emoji="🏥" onclick="pickEmoji(this)">🏥</div>
+        <div class="emoji-opt" data-emoji="💊" onclick="pickEmoji(this)">💊</div>
+        <div class="emoji-opt" data-emoji="📊" onclick="pickEmoji(this)">📊</div>
+        <div class="emoji-opt" data-emoji="🔬" onclick="pickEmoji(this)">🔬</div>
+        <div class="emoji-opt" data-emoji="🌿" onclick="pickEmoji(this)">🌿</div>
+        <div class="emoji-opt" data-emoji="🛡" onclick="pickEmoji(this)">🛡</div>
+        <div class="emoji-opt" data-emoji="📡" onclick="pickEmoji(this)">📡</div>
+        <div class="emoji-opt" data-emoji="🔗" onclick="pickEmoji(this)">🔗</div>
+      </div>
+    </div>
+
+    <div class="modal-field">
+      <div class="modal-label">Accent Color</div>
+      <div class="color-picker-row" id="colorPicker">
+        <div class="color-opt selected" data-color="#018bff" style="background:#018bff" onclick="pickColor(this)"></div>
+        <div class="color-opt" data-color="#8b5cf6" style="background:#8b5cf6" onclick="pickColor(this)"></div>
+        <div class="color-opt" data-color="#10b981" style="background:#10b981" onclick="pickColor(this)"></div>
+        <div class="color-opt" data-color="#f59e0b" style="background:#f59e0b" onclick="pickColor(this)"></div>
+        <div class="color-opt" data-color="#ef4444" style="background:#ef4444" onclick="pickColor(this)"></div>
+        <div class="color-opt" data-color="#ec4899" style="background:#ec4899" onclick="pickColor(this)"></div>
+        <div class="color-opt" data-color="#14b8a6" style="background:#14b8a6" onclick="pickColor(this)"></div>
+      </div>
+    </div>
+
+    <div class="modal-actions">
+      <button class="modal-btn modal-btn-cancel" onclick="closeModal()">Cancel</button>
+      <button class="modal-btn modal-btn-add" onclick="addGraph()">Add Graph</button>
+    </div>
+  </div>
+</div>
+
+<script>
+let graphs = [];
+let activeIdx = null;
+let instanceUrl = 'http://localhost:7474';
+let connected = false;
+let selectedEmoji = '🕸';
+let selectedColor = '#018bff';
+
+const defaultGraphs = [
+  {
+    name: 'HC/PHAC Platform Ontology',
+    db: 'platform',
+    desc: 'Enterprise AI platform capability graph — PATH/HAIL architecture entities and relationships',
+    tags: ['architecture', 'EA', 'platform'],
+    icon: '🕸',
+    color: '#018bff'
+  },
+  {
+    name: 'PMRA Regulatory Knowledge',
+    db: 'pmra',
+    desc: 'Regulatory submissions, decisions, compounds, and post-market surveillance links',
+    tags: ['regulatory', 'Protected B', 'PMRA'],
+    icon: '💊',
+    color: '#8b5cf6'
+  },
+  {
+    name: 'Surveillance Signal Graph',
+    db: 'surveillance',
+    desc: 'CDC/WHO signal entities, disease taxonomy, geographic nodes, outbreak correlations',
+    tags: ['surveillance', 'public health', 'PHAC'],
+    icon: '🧬',
+    color: '#10b981'
+  },
+  {
+    name: 'Capability Cluster Map',
+    db: 'capabilities',
+    desc: "Cluster taxonomy — IT proposals, dependencies, and capability domain relationships",
+    tags: ['EA', 'clusters', 'investment'],
+    icon: '📊',
+    color: '#f59e0b'
+  }
+];
+
+function init() {
+  graphs = [...defaultGraphs];
+  renderGraphs();
+}
+
+async function connect() {
+  instanceUrl = document.getElementById('instanceUrl').value.trim() || 'http://localhost:7474';
+  const connectBtn = document.getElementById('connectBtn');
+  const connDot = document.getElementById('connDot');
+  const connLabel = document.getElementById('connLabel');
+  connectBtn.disabled = true;
+  connLabel.textContent = 'Connecting...';
+  connDot.className = 'conn-dot';
+
+  try {
+    await fetch(`${instanceUrl}/browser/`, { mode: 'no-cors' });
+    connected = true;
+    connDot.className = 'conn-dot live';
+    connLabel.textContent = instanceUrl.replace('http://', '').replace('https://', '');
+    document.getElementById('footerInstance').textContent = connLabel.textContent;
+
+    if (activeIdx === null && graphs.length > 0) {
+      loadGraph(0);
+    } else if (activeIdx !== null) {
+      buildFrameUrl(graphs[activeIdx]);
+    }
+  } catch (err) {
+    connected = false;
+    connDot.className = 'conn-dot err';
+    connLabel.textContent = 'Connection failed';
+    console.error('Failed to connect to Neo4j instance', err);
+  } finally {
+    connectBtn.disabled = false;
+  }
+}
+
+function renderGraphs() {
+  const list = document.getElementById('graphList');
+  document.getElementById('footerGraphCount').textContent = String(graphs.length);
+  list.textContent = '';
+
+  graphs.forEach((g, i) => {
+    const card = document.createElement('div');
+    card.className = `graph-card ${i === activeIdx ? 'active' : ''}`;
+    card.addEventListener('click', () => loadGraph(i));
+
+    const top = document.createElement('div');
+    top.className = 'gc-top';
+
+    const icon = document.createElement('div');
+    icon.className = 'gc-icon';
+    icon.style.background = hexBg(g.color);
+    icon.textContent = g.icon;
+
+    const body = document.createElement('div');
+    body.className = 'gc-body';
+
+    const name = document.createElement('div');
+    name.className = 'gc-name';
+    name.textContent = g.name;
+
+    const db = document.createElement('div');
+    db.className = 'gc-db';
+    db.textContent = `db: ${g.db}`;
+
+    body.append(name, db);
+    top.append(icon, body);
+
+    const tags = document.createElement('div');
+    tags.className = 'gc-tags';
+    g.tags.forEach(t => {
+      const tag = document.createElement('span');
+      tag.className = 'gc-tag';
+      tag.textContent = t;
+      tags.appendChild(tag);
     });
-  </script>
+
+    card.append(top, tags);
+    list.appendChild(card);
+  });
+}
+
+function hexBg(hex) {
+  return hex + '18';
+}
+
+function loadGraph(idx) {
+  activeIdx = idx;
+  const g = graphs[idx];
+  renderGraphs();
+
+  document.getElementById('topBarIcon').textContent = g.icon;
+  document.getElementById('topBarIcon').style.background = hexBg(g.color);
+  document.getElementById('topBarName').textContent = g.name;
+
+  const dbBadge = document.getElementById('topBarDb');
+  dbBadge.textContent = `db: ${g.db}`;
+  dbBadge.style.display = 'inline-flex';
+
+  document.getElementById('footerActiveDb').textContent = g.db;
+
+  if (!connected) {
+    document.getElementById('placeholder').classList.remove('hidden');
+    document.getElementById('neo4jFrame').style.display = 'none';
+    return;
+  }
+
+  buildFrameUrl(g);
+}
+
+function buildFrameUrl(g) {
+  const base = instanceUrl.replace(/\/$/, '');
+  const boltUrl = base.replace(/:\d+$/, ':7687').replace('http://', 'bolt://').replace('https://', 'bolt+s://');
+
+  const params = new URLSearchParams({
+    connectURL: boltUrl,
+    db: g.db
+  });
+
+  const frameUrl = `${base}/browser/?${params.toString()}`;
+  const frame = document.getElementById('neo4jFrame');
+  frame.src = frameUrl;
+  frame.style.display = 'block';
+  document.getElementById('placeholder').classList.add('hidden');
+}
+
+function reloadFrame() {
+  if (activeIdx === null) return;
+  const frame = document.getElementById('neo4jFrame');
+  frame.src = frame.src;
+}
+
+function openInTab() {
+  if (activeIdx === null) return;
+  const frame = document.getElementById('neo4jFrame');
+  if (frame.src) window.open(frame.src, '_blank', 'noopener,noreferrer');
+}
+
+function openNeo4jDirect() {
+  const base = (document.getElementById('instanceUrl').value.trim() || instanceUrl || 'http://localhost:7474').replace(/\/$/, '');
+  window.open(base + '/browser/', '_blank', 'noopener,noreferrer');
+}
+
+function openAddModal() {
+  document.getElementById('modalOverlay').classList.add('open');
+  document.getElementById('newName').focus();
+}
+
+function closeModal() {
+  document.getElementById('modalOverlay').classList.remove('open');
+  document.getElementById('newName').value = '';
+  document.getElementById('newDb').value = '';
+  document.getElementById('newDesc').value = '';
+  document.getElementById('newTags').value = '';
+  selectedEmoji = '🕸';
+  selectedColor = '#018bff';
+  document.querySelectorAll('.emoji-opt').forEach(e => e.classList.remove('selected'));
+  document.querySelector('.emoji-opt').classList.add('selected');
+  document.querySelectorAll('.color-opt').forEach(e => e.classList.remove('selected'));
+  document.querySelector('.color-opt').classList.add('selected');
+}
+
+function closeModalIfBg(e) {
+  if (e.target === document.getElementById('modalOverlay')) closeModal();
+}
+
+function pickEmoji(el) {
+  document.querySelectorAll('.emoji-opt').forEach(e => e.classList.remove('selected'));
+  el.classList.add('selected');
+  selectedEmoji = el.dataset.emoji;
+}
+
+function pickColor(el) {
+  document.querySelectorAll('.color-opt').forEach(e => e.classList.remove('selected'));
+  el.classList.add('selected');
+  selectedColor = el.dataset.color;
+}
+
+function addGraph() {
+  const name = document.getElementById('newName').value.trim();
+  const db = document.getElementById('newDb').value.trim() || 'neo4j';
+  const desc = document.getElementById('newDesc').value.trim();
+  const tags = document.getElementById('newTags').value.split(',').map(t => t.trim()).filter(Boolean);
+
+  if (!name) {
+    document.getElementById('newName').focus();
+    return;
+  }
+
+  graphs.push({ name, db, desc, tags, icon: selectedEmoji, color: selectedColor });
+  renderGraphs();
+  closeModal();
+
+  if (connected) loadGraph(graphs.length - 1);
+}
+
+document.addEventListener('keydown', e => {
+  if (e.key === 'Escape') closeModal();
+  if (e.key === 'ArrowDown' && document.activeElement === document.body) {
+    if (activeIdx === null) loadGraph(0);
+    else if (activeIdx < graphs.length - 1) loadGraph(activeIdx + 1);
+  }
+  if (e.key === 'ArrowUp' && document.activeElement === document.body) {
+    if (activeIdx !== null && activeIdx > 0) loadGraph(activeIdx - 1);
+  }
+});
+
+init();
+</script>
 </body>
 </html>

--- a/submit.html
+++ b/submit.html
@@ -14,6 +14,24 @@
     h1 {
       color: #333;
     }
+    .nav {
+      display: flex;
+      gap: 8px;
+      margin-bottom: 14px;
+      flex-wrap: wrap;
+    }
+    .nav a {
+      text-decoration: none;
+      font-size: 12px;
+      border: 1px solid #ccc;
+      border-radius: 5px;
+      color: #333;
+      padding: 6px 10px;
+      background: #fff;
+    }
+    .nav a:hover {
+      background: #f0f0f0;
+    }
     form {
       background: white;
       padding: 20px;
@@ -42,6 +60,11 @@
   </style>
 </head>
 <body>
+  <nav class="nav">
+    <a href="index.html">Knowledge Graph Explorer</a>
+    <a href="architecture-fitness-agent.html">Architecture Fitness Agent</a>
+    <a href="submit.html">Admin Log Entry</a>
+  </nav>
   <h1>🗳️ State of Democracy Tracker – Admin Entry</h1>
   <form id="democracyForm">
     <label for="date">Date:</label>


### PR DESCRIPTION
### Motivation
- Replace the previous RSS dashboard with a Knowledge Graph Explorer to provide an interactive Neo4j-backed interface for HC/PHAC enterprise graphs.
- Add an Architecture Fitness Agent single-page app to evaluate proposed solutions against the HC/PHAC reference architecture and optionally query live Azure via MCP.
- Improve cross-site navigation and the admin submit page to unify the tools and make graphs and assessments discoverable.

### Description
- Added `architecture-fitness-agent.html` implementing a complete single-file UI, styling, system prompt, Anthropic API integration (Claude Sonnet model), optional Azure MCP server support, chat/history state, JSON response parsing, and result rendering across six evaluation dimensions.
- Replaced the old `index.html` contents with a full Knowledge Graph Explorer UI that includes a styled sidebar, Neo4j connection controls, graph list management, an add-graph modal, and an iframe loader for the Neo4j browser with logic to build the connection URL and manage active graphs.
- Updated `submit.html` to include a top navigation, improved styling, and links to the new pages to unify navigation across the site.

### Testing
- No automated tests were run for these UI/HTML/JS changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2a0effff083229468d1ec5d5cf387)