### PR TITLE
Fix malformed workflow configs for feed health and uptime jobs

### DIFF
--- a/news_pipeline.yml
+++ b/news_pipeline.yml
@@ -1,5 +1,3 @@
-# .github/workflows/news_pipeline.yml
-
 name: News Briefing Pipeline
 
 on:
@@ -16,21 +14,22 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           persist-credentials: true
 
       - name: Set up Python 3.x
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.x'
 
       - name: Install Python dependencies
         run: |
-          pip install pyyaml requests openai
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
 
       - name: List repository contents
-        run: ls -R .
+        run: find . -maxdepth 2 -type f
 
       - name: Run RSS feed tests
         run: python test_feeds.py
@@ -41,6 +40,7 @@ jobs:
           author_name: 'github-actions'
           author_email: 'github-actions@github.com'
           message: 'chore: update health.json'
+          add: 'health.json'
 
       - name: Generate latest briefing
         env:
@@ -53,3 +53,4 @@ jobs:
           author_name: 'github-actions'
           author_email: 'github-actions@github.com'
           message: 'chore: update latest.txt'
+          add: 'latest.txt'

--- a/ping_canadian_feeds.yml
+++ b/ping_canadian_feeds.yml
@@ -1,93 +1,66 @@
-.github/workflows/ping_canadian_feeds.yml
-
 name: Canadian Feed Uptime Pings
 
 on:
-schedule:
-- cron: ‘0 * * * *’  # every hour on the hour
-workflow_dispatch:
+  schedule:
+    - cron: '0 * * * *' # every hour on the hour
+  workflow_dispatch:
 
 jobs:
-ping-canadian-feeds:
-runs-on: ubuntu-latest
+  ping-canadian-feeds:
+    runs-on: ubuntu-latest
 
-steps:
-  - name: Check out repo
-    uses: actions/checkout@v4
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v4
 
-  - name: Install dependencies
-    run: |
-      pip install requests feedparser
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install requests feedparser
 
-  - name: Ping CBC & CTV feeds
-    id: ping
-    run: |
-      python3 - << 'EOF'
-      import json, requests, feedparser
-      from datetime import datetime
+      - name: Ping CBC & CTV feeds
+        run: |
+          python3 - <<'EOF'
+          import json
+          from datetime import datetime
 
-      feeds = {
-        "CBC": "https://rss.cbc.ca/lineup/topstories.xml",
-        "CTV": "https://www.ctvnews.ca/rss/ctvnews-ca-canada-1.2089050"
-      }
+          import feedparser
+          import requests
 
-      timestamp = datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ')
-      record = {"timestamp": timestamp}
-      for name, url in feeds.items():
+          feeds = {
+              "CBC": "https://rss.cbc.ca/lineup/topstories.xml",
+              "CTV": "https://www.ctvnews.ca/rss/ctvnews-ca-canada-1.2089050",
+          }
+
+          timestamp = datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ')
+          record = {"timestamp": timestamp}
+          for name, url in feeds.items():
+              try:
+                  response = requests.get(url, timeout=10)
+                  response.raise_for_status()
+                  record[name] = bool(feedparser.parse(response.content).entries)
+              except Exception:
+                  record[name] = False
+
+          path = 'uptime.json'
           try:
-              r = requests.get(url, timeout=10); r.raise_for_status()
-              record[name] = bool(feedparser.parse(r.content).entries)
-          except:
-              record[name] = False
+              with open(path, 'r', encoding='utf-8') as f:
+                  data = json.load(f)
+          except Exception:
+              data = []
 
-      # Load existing uptime.json or init
-      path = 'uptime.json'
-      try:
-          data = json.load(open(path))
-      except:
-          data = []
+          data.append(record)
+          data = data[-168:]
 
-      data.append(record)
-      # Keep last 168 entries (~7 days hourly)
-      data = data[-168:]
+          with open(path, 'w', encoding='utf-8') as f:
+              json.dump(data, f, indent=2)
+          EOF
 
-      with open(path, 'w') as f:
-          json.dump(data, f, indent=2)
-      EOF
-
-  - name: Commit & push uptime.json
-    run: |
-      git config user.name "github-actions[bot]"
-      git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-      git add uptime.json
-      git commit -m "Add uptime ping ${{ steps.ping.outputs.timestamp }}" || echo "No changes"
-      git push
-
-
-⸻
-
-.github/workflows/pages-build-deployment.yml
-
-name: Deploy GitHub Pages
-
-on:
-push:
-branches:
-- main
-
-jobs:
-build-and-deploy:
-runs-on: ubuntu-latest
-
-steps:
-  - name: Checkout repository
-    uses: actions/checkout@v4
-
-  - name: Deploy to GitHub Pages
-    uses: peaceiris/actions-gh-pages@v3
-    with:
-      github_token: ${{ secrets.GITHUB_TOKEN }}
-      publish_dir: './'
-      publish_branch: gh-pages
-      user_name: github-actions[bot]
-      user_email: 41898282+github-actions[bot]@users.noreply.github.com
+      - name: Commit & push uptime.json
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add uptime.json
+          ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          git commit -m "chore: add uptime ping ${ts}" || echo "No changes"
+          git push


### PR DESCRIPTION
### Motivation
- The scheduled workflows for the news pipeline and Canadian uptime pings were malformed and contained stray pasted content, broken YAML/indentation, and incorrect commands that prevented reliable CI runs.
- The intent is to restore the feed-health and uptime automation to runnable, modern GitHub Actions definitions and make dependency installation deterministic.

### Description
- Updated `news_pipeline.yml` to use current action versions (`actions/checkout@v4`, `actions/setup-python@v5`), install dependencies from `requirements.txt`, and run `python -m pip install --upgrade pip` before installs.
- Replaced the recursive `ls -R .` with a bounded file listing using `find . -maxdepth 2 -type f`, and set explicit `add` paths for the commit steps so only `health.json` and `latest.txt` are committed.
- Rewrote `ping_canadian_feeds.yml` to be valid YAML with correct `on.schedule` and `workflow_dispatch` structure, fixed step/indentation layout, hardened the inline Python ping script (explicit imports, `encoding='utf-8'` read/write), and made the uptime commit generate a real UTC timestamp in-shell before committing.
- Removed stray/pasted content from the uptime workflow and standardized dependency installation to use `python -m pip install --upgrade pip` followed by required packages.

### Testing
- Parsed both workflow files with `yaml.safe_load` (via a small `python` snippet) which printed `news_pipeline.yml: OK` and `ping_canadian_feeds.yml: OK` indicating valid YAML.
- Ran `pytest -q` which reported `no tests ran` (there are no unit tests defined), so no test failures occurred.
- Verified the modified workflow files by printing their contents to confirm the corrected structure and commit-related fields were present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e40511139c8322ad4469dfb24e795c)