### PR TITLE
Add top navigation, deep-links for PATH/HAIL/Control Plane, and Tools (PPTX) artifacts page

### DIFF
--- a/artifacts.html
+++ b/artifacts.html
@@ -1,0 +1,123 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>PATH Artifacts and Tools</title>
+  <style>
+    :root {
+      --bg: #0b1220;
+      --panel: #121b2f;
+      --line: #2a3555;
+      --text: #d7e1ff;
+      --muted: #9eb0da;
+      --accent: #6db4ff;
+    }
+
+    * { box-sizing: border-box; }
+
+    body {
+      margin: 0;
+      font-family: Inter, "Segoe UI", system-ui, sans-serif;
+      background: radial-gradient(circle at 25% -10%, #1a2b52, var(--bg) 50%);
+      color: var(--text);
+    }
+
+    .top-nav {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.6rem;
+      max-width: 960px;
+      margin: 0 auto;
+      padding: 1rem 1.5rem 0;
+    }
+
+    .top-nav a {
+      border: 1px solid #2f4d83;
+      color: #b8c9f2;
+      text-decoration: none;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      font-size: 0.8rem;
+      padding: 0.5rem 0.8rem;
+      border-radius: 8px;
+      background: #121d35;
+    }
+
+    .top-nav a.active {
+      color: #d7e1ff;
+      border-color: #5d83ce;
+      background: #1a2c50;
+    }
+
+    .wrap {
+      max-width: 960px;
+      margin: 0 auto;
+      padding: 1.5rem;
+    }
+
+    .panel {
+      border: 1px solid var(--line);
+      border-radius: 14px;
+      background: color-mix(in srgb, var(--panel), #000 8%);
+      padding: 1.1rem 1.2rem;
+      margin-bottom: 1rem;
+    }
+
+    h1 {
+      margin: 0.3rem 0 0.5rem;
+      font-size: 1.6rem;
+    }
+
+    p, li {
+      color: var(--muted);
+      font-size: 0.95rem;
+      line-height: 1.5;
+    }
+
+    .eyebrow {
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      font-size: 0.78rem;
+    }
+
+    .tool-list {
+      margin: 0.6rem 0 0;
+      padding-left: 1.2rem;
+    }
+
+    a { color: var(--accent); }
+  </style>
+</head>
+<body>
+  <nav class="top-nav" aria-label="Site navigation">
+    <a href="./index.html">Overview</a>
+    <a href="./intelligence.html">PATH</a>
+    <a href="./intelligence.html#enterprise-positioning">HAIL</a>
+    <a href="./intelligence.html#control-plane">Control Plane</a>
+    <a class="active" href="./artifacts.html">Tools (PPTX)</a>
+  </nav>
+
+  <main class="wrap">
+    <section class="panel">
+      <p class="eyebrow">Artifacts + Delivery</p>
+      <h1>PPTX Builder Tools</h1>
+      <p>This page centralizes slide-delivery artifacts and entry points for the PATH presentation workflow.</p>
+      <ul class="tool-list">
+        <li><strong>Builder UI:</strong> compose narrative structure and slide order for executive briefings.</li>
+        <li><strong>Print / PDF Ready:</strong> export an offline-ready format for review and circulation.</li>
+        <li><strong>MCP Scaffold:</strong> prepare reusable scaffolding for automated deck generation.</li>
+      </ul>
+    </section>
+
+    <section class="panel">
+      <h2>Linked Intelligence Inputs</h2>
+      <ul class="tool-list">
+        <li><a href="./intelligence.html">PATH intelligence overview</a></li>
+        <li><a href="./intelligence.html#control-plane">Control plane model and policy controls</a></li>
+        <li><a href="./intelligence.html#enterprise-positioning">HAIL and PATH enterprise positioning</a></li>
+      </ul>
+    </section>
+  </main>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -39,6 +39,33 @@
       padding: 1rem;
     }
 
+    .top-nav {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.6rem;
+      padding: 1rem 1rem 0;
+      max-width: 1600px;
+      margin: 0 auto;
+    }
+
+    .top-nav a {
+      border: 1px solid #2f4d83;
+      color: #b8c9f2;
+      text-decoration: none;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      font-size: 0.8rem;
+      padding: 0.5rem 0.8rem;
+      border-radius: 8px;
+      background: #121d35;
+    }
+
+    .top-nav a.active {
+      color: #d7e1ff;
+      border-color: #5d83ce;
+      background: #1a2c50;
+    }
+
     .rail,
     .canvas,
     .intel {
@@ -314,6 +341,13 @@
   </style>
 </head>
 <body>
+  <nav class="top-nav" aria-label="Site navigation">
+    <a class="active" href="./index.html">Overview</a>
+    <a href="./intelligence.html">PATH</a>
+    <a href="./intelligence.html#enterprise-positioning">HAIL</a>
+    <a href="./intelligence.html#control-plane">Control Plane</a>
+    <a href="./artifacts.html">Tools (PPTX)</a>
+  </nav>
   <div class="app-shell">
     <aside class="rail">
       <div class="brand">AI Control Surface</div>

--- a/intelligence.html
+++ b/intelligence.html
@@ -35,6 +35,33 @@
       gap: 1rem;
     }
 
+    .top-nav {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.6rem;
+      max-width: 1120px;
+      margin: 0 auto;
+      padding: 1rem 1.5rem 0;
+    }
+
+    .top-nav a {
+      border: 1px solid #2f4d83;
+      color: #b8c9f2;
+      text-decoration: none;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      font-size: 0.8rem;
+      padding: 0.5rem 0.8rem;
+      border-radius: 8px;
+      background: #121d35;
+    }
+
+    .top-nav a.active {
+      color: #d7e1ff;
+      border-color: #5d83ce;
+      background: #1a2c50;
+    }
+
     .hero,
     section {
       background: color-mix(in srgb, var(--panel), #000 8%);
@@ -137,6 +164,13 @@
   </style>
 </head>
 <body>
+  <nav class="top-nav" aria-label="Site navigation">
+    <a href="./index.html">Overview</a>
+    <a class="active" href="./intelligence.html">PATH</a>
+    <a href="#enterprise-positioning">HAIL</a>
+    <a href="#control-plane">Control Plane</a>
+    <a href="./artifacts.html">Tools (PPTX)</a>
+  </nav>
   <main class="wrap">
     <header class="hero">
       <p class="eyebrow">Health Canada / PHAC Enterprise AI</p>
@@ -189,7 +223,7 @@
       </table>
     </section>
 
-    <section>
+    <section id="control-plane">
       <h2>3) Canonical PATH Architecture: Three Planes + Reuse</h2>
       <h3>A. Control Plane (PATH Core)</h3>
       <ul>
@@ -245,7 +279,7 @@
       <p><strong>Lifecycle:</strong> Build → Test → Govern → Deploy → Audit → Improve.</p>
     </section>
 
-    <section>
+    <section id="enterprise-positioning">
       <h2>5) Enterprise Positioning: Data Platform, HAIL, and PATH</h2>
       <table>
         <thead>

--- a/path-architecture.html
+++ b/path-architecture.html
@@ -35,6 +35,33 @@
       gap: 1rem;
     }
 
+    .top-nav {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.6rem;
+      max-width: 1100px;
+      margin: 0 auto;
+      padding: 1rem 1.5rem 0;
+    }
+
+    .top-nav a {
+      border: 1px solid #2f4d83;
+      color: #b8c9f2;
+      text-decoration: none;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      font-size: 0.8rem;
+      padding: 0.5rem 0.8rem;
+      border-radius: 8px;
+      background: #121d35;
+    }
+
+    .top-nav a.active {
+      color: #d7e1ff;
+      border-color: #5d83ce;
+      background: #1a2c50;
+    }
+
     .hero,
     section {
       background: color-mix(in srgb, var(--panel), #000 8%);
@@ -137,6 +164,13 @@
   </style>
 </head>
 <body>
+  <nav class="top-nav" aria-label="Site navigation">
+    <a href="./index.html">Overview</a>
+    <a class="active" href="./path-architecture.html">PATH</a>
+    <a href="#enterprise-positioning">HAIL</a>
+    <a href="#control-plane">Control Plane</a>
+    <a href="./artifacts.html">Tools (PPTX)</a>
+  </nav>
   <main class="wrap">
     <header class="hero">
       <p class="eyebrow">Health Canada / PHAC Enterprise AI</p>
@@ -189,7 +223,7 @@
       </table>
     </section>
 
-    <section>
+    <section id="control-plane">
       <h2>3) Canonical PATH Architecture: Three Planes + Reuse</h2>
       <h3>A. Control Plane (PATH Core)</h3>
       <ul>
@@ -245,7 +279,7 @@
       <p><strong>Lifecycle:</strong> Build → Test → Govern → Deploy → Audit → Improve.</p>
     </section>
 
-    <section>
+    <section id="enterprise-positioning">
       <h2>5) Enterprise Positioning: Data Platform, HAIL, and PATH</h2>
       <table>
         <thead>


### PR DESCRIPTION
### Motivation
- Several site pages (notably intelligence and artifacts/tools) were not reachable from the main UI, so a site-level navigation and deep-links were needed to expose Overview, PATH, HAIL, Control Plane, and Tools (PPTX).
- Provide a stable landing for slide/deck artifacts so the PPTX builder/tools are discoverable and cross-linked with intelligence content.

### Description
- Added a reusable `.top-nav` (CSS + markup) and inserted it into `index.html`, `intelligence.html`, and `path-architecture.html` so the top navigation appears site-wide and matches the existing dark theme.
- Added deep-link anchor IDs `#control-plane` and `#enterprise-positioning` in `intelligence.html` and `path-architecture.html` and wired the nav to those anchors for direct jumps to Control Plane and HAIL sections.
- Created a new `artifacts.html` page as the Tools (PPTX) landing with the same top-nav and links back to intelligence sections.
- Updated internal links across pages so the nav contains five consistent entries: `Overview`, `PATH`, `HAIL`, `Control Plane`, and `Tools (PPTX)`.

### Testing
- Ran a Python HTMLParser-based validation that checks each page contains the `top-nav`, asserts there are exactly 5 nav links, verifies target files exist, and verifies anchors exist, and it passed (`navigation checks passed`).
- Attempted a BeautifulSoup-based validation but it failed due to a missing local dependency (`ModuleNotFoundError: No module named 'bs4'`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e41ddf413c8322989a60f14c2aa18e)