### PR TITLE
Improve mobile responsiveness for dashboard and briefing pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -287,6 +287,7 @@
       animation: row-in 380ms ease forwards;
     }
 
+
     @media (max-width: 1100px) {
       .app-shell {
         grid-template-columns: 1fr;
@@ -294,6 +295,54 @@
       .grid { grid-template-columns: 1fr; }
     }
 
+    @media (max-width: 768px) {
+      .app-shell {
+        gap: 0.75rem;
+        padding: 0.65rem;
+      }
+
+      .rail,
+      .canvas,
+      .intel {
+        padding: 0.85rem;
+        border-radius: 12px;
+      }
+
+      .rail {
+        order: 1;
+      }
+
+      .canvas {
+        order: 2;
+      }
+
+      .intel {
+        order: 3;
+      }
+
+      .nav-list {
+        grid-auto-flow: column;
+        grid-auto-columns: max-content;
+        overflow-x: auto;
+        overscroll-behavior-x: contain;
+        padding-bottom: 0.2rem;
+        margin-right: -0.2rem;
+      }
+
+      .nav-list li {
+        white-space: nowrap;
+      }
+
+      .timeline-table {
+        display: block;
+        overflow-x: auto;
+        white-space: nowrap;
+      }
+
+      #latest-briefing {
+        max-height: 240px;
+      }
+    }
     @keyframes shimmer {
       0% { background-position: 100% 0; }
       100% { background-position: -100% 0; }

--- a/intelligence.html
+++ b/intelligence.html
@@ -134,6 +134,48 @@
     }
 
     a { color: var(--accent); }
+
+    @media (max-width: 768px) {
+      .wrap {
+        padding: 0.85rem;
+        gap: 0.8rem;
+      }
+
+      .hero,
+      section {
+        padding: 0.95rem;
+        border-radius: 12px;
+      }
+
+      .eyebrow {
+        font-size: 0.72rem;
+        letter-spacing: 0.09em;
+      }
+
+      h1 {
+        font-size: 1.35rem;
+        margin-top: 0.35rem;
+      }
+
+      h2 {
+        font-size: 1rem;
+      }
+
+      p,
+      li {
+        font-size: 0.98rem;
+      }
+
+      .grid-2 {
+        grid-template-columns: 1fr;
+      }
+
+      table {
+        display: block;
+        overflow-x: auto;
+        white-space: nowrap;
+      }
+    }
   </style>
 </head>
 <body>

--- a/path-architecture.html
+++ b/path-architecture.html
@@ -134,6 +134,48 @@
     }
 
     a { color: var(--accent); }
+
+    @media (max-width: 768px) {
+      .wrap {
+        padding: 0.85rem;
+        gap: 0.8rem;
+      }
+
+      .hero,
+      section {
+        padding: 0.95rem;
+        border-radius: 12px;
+      }
+
+      .eyebrow {
+        font-size: 0.72rem;
+        letter-spacing: 0.09em;
+      }
+
+      h1 {
+        font-size: 1.35rem;
+        margin-top: 0.35rem;
+      }
+
+      h2 {
+        font-size: 1rem;
+      }
+
+      p,
+      li {
+        font-size: 0.98rem;
+      }
+
+      .grid-2 {
+        grid-template-columns: 1fr;
+      }
+
+      table {
+        display: block;
+        overflow-x: auto;
+        white-space: nowrap;
+      }
+    }
   </style>
 </head>
 <body>


### PR DESCRIPTION
### Motivation
- Make the site layouts behave better on narrow screens while preserving the existing large-screen placement and visual hierarchy. 
- Provide a compact, phone-friendly flow for the three-column dashboard and the briefing pages so content is readable without horizontal clipping. 
- Match the preferred compact/tab-like mobile appearance by converting navigation into a scrollable row and improving table handling.

### Description
- Added a `@media (max-width: 768px)` mobile stylesheet to `index.html` that reduces shell/card padding, stacks the three panels, and sets a mobile ordering of `rail`, `canvas`, then `intel` for a logical phone flow. 
- Converted `.nav-list` into a horizontally scrollable row (`grid-auto-flow: column`, `overflow-x: auto`) and constrained table layouts with `display: block` + `overflow-x: auto` to avoid cramped columns on narrow screens in `index.html`. 
- Added matching mobile breakpoint rules to `intelligence.html` and `path-architecture.html` that tighten spacing, adjust heading/body sizes, collapse `.grid-2` to a single column, and enable horizontal overflow for tables. 

### Testing
- Ran `git diff --check` to validate there are no whitespace or formatting issues and it returned clean. 
- Verified the changes are scoped to mobile breakpoints (`max-width: 768px`) so desktop/tablet layouts remain unchanged. 
- Confirmed the three files modified are `index.html`, `intelligence.html`, and `path-architecture.html` and that the new CSS blocks are only applied at the mobile breakpoint.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e43193ce708322b0b4731b597aaf30)