### PR TITLE
Standardize top navigation controls across all pages

### DIFF
--- a/artifacts.html
+++ b/artifacts.html
@@ -136,9 +136,54 @@
     }
 
     a.home:hover { text-decoration: underline; }
+
+    .top-nav {
+      max-width: 1100px;
+      margin: 1rem auto 0;
+      padding: 0 1.3rem;
+    }
+
+    .top-nav-list {
+      list-style: none;
+      margin: 0;
+      padding: 0.65rem;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.55rem;
+      border-radius: 12px;
+      border: 1px solid var(--line);
+      background: color-mix(in srgb, var(--panel), #000 8%);
+    }
+
+    .top-nav-list a {
+      display: inline-block;
+      text-decoration: none;
+      color: var(--muted);
+      border: 1px solid #324870;
+      background: #13213f;
+      border-radius: 999px;
+      padding: 0.35rem 0.7rem;
+      font-size: 0.84rem;
+      font-weight: 600;
+    }
+
+    .top-nav-list a.active {
+      color: var(--text);
+      border-color: #4f79c6;
+      background: #1e386b;
+    }
   </style>
 </head>
 <body>
+  <nav class="top-nav" aria-label="Primary">
+    <ul class="top-nav-list">
+      <li><a href="./index.html">News Dashboard</a></li>
+      <li><a href="./intelligence.html">PATH Intelligence</a></li>
+      <li><a href="./path-architecture.html">PATH Architecture</a></li>
+      <li><a href="./artifacts.html" class="active">Artifacts Index</a></li>
+      <li><a href="./submit.html">Admin Entry</a></li>
+    </ul>
+  </nav>
   <main class="wrap">
     <section class="panel">
       <h1>Artifacts Index</h1>

--- a/index.html
+++ b/index.html
@@ -287,6 +287,41 @@
       animation: row-in 380ms ease forwards;
     }
 
+    .top-nav {
+      margin-bottom: 0.2rem;
+      grid-column: 1 / -1;
+    }
+
+    .top-nav-list {
+      list-style: none;
+      margin: 0;
+      padding: 0.65rem;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.55rem;
+      border-radius: 12px;
+      border: 1px solid var(--line);
+      background: color-mix(in srgb, var(--panel), #000 8%);
+    }
+
+    .top-nav-list a {
+      display: inline-block;
+      text-decoration: none;
+      color: var(--muted);
+      border: 1px solid #324870;
+      background: #13213f;
+      border-radius: 999px;
+      padding: 0.35rem 0.7rem;
+      font-size: 0.84rem;
+      font-weight: 600;
+    }
+
+    .top-nav-list a.active {
+      color: var(--text);
+      border-color: #4f79c6;
+      background: #1e386b;
+    }
+
 
     @media (max-width: 1100px) {
       .app-shell {
@@ -364,6 +399,15 @@
 </head>
 <body>
   <div class="app-shell">
+  <nav class="top-nav" aria-label="Primary">
+    <ul class="top-nav-list">
+      <li><a href="./index.html" class="active">News Dashboard</a></li>
+      <li><a href="./intelligence.html">PATH Intelligence</a></li>
+      <li><a href="./path-architecture.html">PATH Architecture</a></li>
+      <li><a href="./artifacts.html">Artifacts Index</a></li>
+      <li><a href="./submit.html">Admin Entry</a></li>
+    </ul>
+  </nav>
     <aside class="rail">
       <div class="brand">AI Control Surface</div>
       <h1>News Ops Dashboard</h1>

--- a/intelligence.html
+++ b/intelligence.html
@@ -135,6 +135,43 @@
 
     a { color: var(--accent); }
 
+    
+    .top-nav {
+      max-width: 1120px;
+      margin: 1rem auto 0;
+      padding: 0 1.5rem;
+    }
+
+    .top-nav-list {
+      list-style: none;
+      margin: 0;
+      padding: 0.65rem;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.55rem;
+      border-radius: 12px;
+      border: 1px solid var(--line);
+      background: color-mix(in srgb, var(--panel), #000 8%);
+    }
+
+    .top-nav-list a {
+      display: inline-block;
+      text-decoration: none;
+      color: var(--muted);
+      border: 1px solid #324870;
+      background: #13213f;
+      border-radius: 999px;
+      padding: 0.35rem 0.7rem;
+      font-size: 0.84rem;
+      font-weight: 600;
+    }
+
+    .top-nav-list a.active {
+      color: var(--text);
+      border-color: #4f79c6;
+      background: #1e386b;
+    }
+
     @media (max-width: 768px) {
       .wrap {
         padding: 0.85rem;
@@ -179,6 +216,15 @@
   </style>
 </head>
 <body>
+  <nav class="top-nav" aria-label="Primary">
+    <ul class="top-nav-list">
+      <li><a href="./index.html">News Dashboard</a></li>
+      <li><a href="./intelligence.html" class="active">PATH Intelligence</a></li>
+      <li><a href="./path-architecture.html">PATH Architecture</a></li>
+      <li><a href="./artifacts.html">Artifacts Index</a></li>
+      <li><a href="./submit.html">Admin Entry</a></li>
+    </ul>
+  </nav>
   <main class="wrap">
     <header class="hero">
       <p class="eyebrow">Health Canada / PHAC Enterprise AI</p>

--- a/path-architecture.html
+++ b/path-architecture.html
@@ -135,6 +135,43 @@
 
     a { color: var(--accent); }
 
+    
+    .top-nav {
+      max-width: 1120px;
+      margin: 1rem auto 0;
+      padding: 0 1.5rem;
+    }
+
+    .top-nav-list {
+      list-style: none;
+      margin: 0;
+      padding: 0.65rem;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.55rem;
+      border-radius: 12px;
+      border: 1px solid var(--line);
+      background: color-mix(in srgb, var(--panel), #000 8%);
+    }
+
+    .top-nav-list a {
+      display: inline-block;
+      text-decoration: none;
+      color: var(--muted);
+      border: 1px solid #324870;
+      background: #13213f;
+      border-radius: 999px;
+      padding: 0.35rem 0.7rem;
+      font-size: 0.84rem;
+      font-weight: 600;
+    }
+
+    .top-nav-list a.active {
+      color: var(--text);
+      border-color: #4f79c6;
+      background: #1e386b;
+    }
+
     @media (max-width: 768px) {
       .wrap {
         padding: 0.85rem;
@@ -179,6 +216,15 @@
   </style>
 </head>
 <body>
+  <nav class="top-nav" aria-label="Primary">
+    <ul class="top-nav-list">
+      <li><a href="./index.html">News Dashboard</a></li>
+      <li><a href="./intelligence.html">PATH Intelligence</a></li>
+      <li><a href="./path-architecture.html" class="active">PATH Architecture</a></li>
+      <li><a href="./artifacts.html">Artifacts Index</a></li>
+      <li><a href="./submit.html">Admin Entry</a></li>
+    </ul>
+  </nav>
   <main class="wrap">
     <header class="hero">
       <p class="eyebrow">Health Canada / PHAC Enterprise AI</p>

--- a/submit.html
+++ b/submit.html
@@ -39,9 +39,49 @@
     button:hover {
       background-color: #004d99;
     }
+
+    .top-nav {
+      margin-bottom: 1rem;
+    }
+    .top-nav-list {
+      list-style: none;
+      margin: 0;
+      padding: 10px;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      border-radius: 10px;
+      border: 1px solid #d8dce6;
+      background: #ffffff;
+    }
+    .top-nav-list a {
+      text-decoration: none;
+      color: #2c467c;
+      border: 1px solid #b5c6ee;
+      background: #edf2ff;
+      border-radius: 999px;
+      padding: 6px 12px;
+      font-size: 0.84rem;
+      font-weight: 600;
+      display: inline-block;
+    }
+    .top-nav-list a.active {
+      color: #ffffff;
+      border-color: #1f59b8;
+      background: #2e68c7;
+    }
   </style>
 </head>
 <body>
+  <nav class="top-nav" aria-label="Primary">
+    <ul class="top-nav-list">
+      <li><a href="./index.html">News Dashboard</a></li>
+      <li><a href="./intelligence.html">PATH Intelligence</a></li>
+      <li><a href="./path-architecture.html">PATH Architecture</a></li>
+      <li><a href="./artifacts.html">Artifacts Index</a></li>
+      <li><a href="./submit.html" class="active">Admin Entry</a></li>
+    </ul>
+  </nav>
   <h1>🗳️ State of Democracy Tracker – Admin Entry</h1>
   <form id="democracyForm">
     <label for="date">Date:</label>


### PR DESCRIPTION
### Motivation
- Pages in the site used inconsistent top navigation placement, labels, and order which made cross-page navigation uneven. 
- The change standardizes the primary navigation so users see the same control set and order on every page. 
- Maintain visual parity with each page theme while ensuring an obvious `active` state for the current page.

### Description
- Added a shared top-of-page navigation block and styling to `index.html`, `intelligence.html`, `path-architecture.html`, `artifacts.html`, and `submit.html` with the unified link order: `News Dashboard`, `PATH Intelligence`, `PATH Architecture`, `Artifacts Index`, `Admin Entry`.
- Implemented consistent CSS for `.top-nav` / `.top-nav-list` and per-page `a.active` styling, and applied a light-theme variant for `submit.html` to match that page’s design.
- Inserted the nav markup at the top of each page so the control is visible immediately and preserved page-specific layout/responsive behavior.

### Testing
- Ran `pytest -q` in the repository which reported no tests were collected (there are no automated tests for the UI in this repo).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e435d3eb6883228cdd6f14b5307d00)