### PR TITLE
QC: update admin entry page wording and form id

### DIFF
--- a/submit.html
+++ b/submit.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>News Briefing Feed – Admin Entry</title>
+  <title>Admin Entry</title>
   <style>
     body {
       font-family: sans-serif;
@@ -82,7 +82,7 @@
       <li><a href="./submit.html" class="active">Admin Entry</a></li>
     </ul>
   </nav>
-  <h1>🗞️ News Briefing Feed – Admin Entry</h1>
+  <h1>🗂️ Admin Entry</h1>
   <form id="adminEntryForm">
     <label for="date">Date:</label>
     <input type="date" id="date" name="date" required>

--- a/submit.html
+++ b/submit.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>State of Democracy Tracker – Admin Log</title>
+  <title>News Briefing Feed – Admin Entry</title>
   <style>
     body {
       font-family: sans-serif;
@@ -82,8 +82,8 @@
       <li><a href="./submit.html" class="active">Admin Entry</a></li>
     </ul>
   </nav>
-  <h1>🗳️ State of Democracy Tracker – Admin Entry</h1>
-  <form id="democracyForm">
+  <h1>🗞️ News Briefing Feed – Admin Entry</h1>
+  <form id="adminEntryForm">
     <label for="date">Date:</label>
     <input type="date" id="date" name="date" required>
 
@@ -112,7 +112,7 @@
   </form>
 
   <script>
-    document.getElementById("democracyForm").addEventListener("submit", function(event) {
+    document.getElementById("adminEntryForm").addEventListener("submit", function(event) {
       event.preventDefault();
       const data = {
         date: this.date.value,
@@ -131,7 +131,7 @@
           alert("Entry submitted successfully.");
           this.reset();
         } else {
-          alert("Submission failed.");
+          alert("Entry submission failed.");
         }
       });
     });


### PR DESCRIPTION
### Motivation
- Replace legacy “State of Democracy” copy and improve form naming and UX consistency with the rest of the news briefing project.

### Description
- Updated the page `<title>` and visible `<h1>` to "News Briefing Feed – Admin Entry", renamed the form id from `democracyForm` to `adminEntryForm` and updated the JavaScript submit listener accordingly, and tightened the failed-submit alert copy to `Entry submission failed.`.

### Testing
- Ran `pytest -q` (no tests collected) and ran `python test_feeds.py`, which executed successfully and wrote `health.json`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4472260e88322950b9f321054c71c)