### PR TITLE
Unify status-site styling and navigation across all pages

### DIFF
--- a/health.html
+++ b/health.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Health History | RSS Feed Status Site</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <header>
+    <h1>RSS Feed Status Site</h1>
+    <p>Feed status checks over time.</p>
+    <nav class="top-nav" aria-label="Primary">
+      <a class="nav-link" href="index.html">Overview</a>
+      <a class="nav-link" href="health.html" aria-current="page">Health History</a>
+      <a class="nav-link" href="uptime.html">Uptime Metrics</a>
+      <a class="nav-link" href="latest.html">Latest Briefing</a>
+    </nav>
+  </header>
+
+  <main>
+    <section class="card">
+      <h2>Health History (last 5 days)</h2>
+      <p>Hover over status cells for full error details when available.</p>
+      <table id="health-table">
+        <thead>
+          <tr><th>Date</th><th>Feed</th><th>Status</th></tr>
+        </thead>
+        <tbody></tbody>
+      </table>
+    </section>
+  </main>
+
+  <footer>
+    <p>Source: <code>health.json</code>.</p>
+  </footer>
+
+  <script>
+    document.addEventListener('DOMContentLoaded', async () => {
+      const tbody = document.querySelector('#health-table tbody');
+      try {
+        const res = await fetch('./health.json');
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const data = await res.json();
+        for (const [date, feeds] of Object.entries(data).slice(-5).reverse()) {
+          for (const [name, status] of Object.entries(feeds)) {
+            const tr = document.createElement('tr');
+            const cls = status.startsWith('ERROR') ? 'bad' : status === 'ZERO' ? 'warn' : 'good';
+            tr.innerHTML = `
+              <td>${date}</td>
+              <td>${name}</td>
+              <td class="${cls}" title="${status}">${status}</td>
+            `;
+            tbody.appendChild(tr);
+          }
+        }
+      } catch (err) {
+        const tr = document.createElement('tr');
+        tr.innerHTML = `<td colspan="3" class="bad">Error loading data: ${err.message}</td>`;
+        tbody.appendChild(tr);
+      }
+    });
+  </script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -3,97 +3,47 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>RSS Feed Health Dashboard</title>
-  <style>
-    body { font-family: sans-serif; margin: 2rem; }
-    table { width: 100%; border-collapse: collapse; margin-top: 1rem; }
-    th, td { border: 1px solid #ccc; padding: 0.5rem; text-align: left; }
-    th { background: #f0f0f0; }
-    .good { color: green; }
-    .warn { color: orange; }
-    .bad  { color: red; }
-    #uptime-list { margin-top: 1rem; list-style: none; padding: 0; }
-    #uptime-list li { margin-bottom: 0.5rem; }
-  </style>
+  <title>RSS Feed Status Site</title>
+  <link rel="stylesheet" href="styles.css">
 </head>
 <body>
-  <h1>RSS Feed Health Dashboard</h1>
-  <p>Showing status for the last five days (hover for details).</p>
-  <table id="health-table">
-    <thead>
-      <tr><th>Date</th><th>Feed</th><th>Status</th></tr>
-    </thead>
-    <tbody></tbody>
-  </table>
+  <header>
+    <h1>RSS Feed Status Site</h1>
+    <p>Monitor feed health, uptime reliability, and the latest generated news briefing.</p>
+    <nav class="top-nav" aria-label="Primary">
+      <a class="nav-link" href="index.html" aria-current="page">Overview</a>
+      <a class="nav-link" href="health.html">Health History</a>
+      <a class="nav-link" href="uptime.html">Uptime Metrics</a>
+      <a class="nav-link" href="latest.html">Latest Briefing</a>
+    </nav>
+  </header>
 
-  <h2>Canadian Feed Uptime (past 7 days)</h2>
-  <ul id="uptime-list"></ul>
+  <main>
+    <section class="card">
+      <h2>Dashboard Overview</h2>
+      <p>Use the navigation above to access every status page. All pages share one stylesheet and one nav structure for consistency.</p>
+      <div class="grid">
+        <article class="card">
+          <h3>Health History</h3>
+          <p>Inspect the last five days of feed status checks from <code>health.json</code>.</p>
+          <p><a href="health.html">Open health history →</a></p>
+        </article>
+        <article class="card">
+          <h3>Uptime Metrics</h3>
+          <p>Review seven-day ping success percentages computed from <code>uptime.json</code>.</p>
+          <p><a href="uptime.html">Open uptime metrics →</a></p>
+        </article>
+        <article class="card">
+          <h3>Latest Briefing</h3>
+          <p>See the most recently generated text briefing from <code>latest.txt</code>.</p>
+          <p><a href="latest.html">Open latest briefing →</a></p>
+        </article>
+      </div>
+    </section>
+  </main>
 
-  <script>
-    document.addEventListener('DOMContentLoaded', async () => {
-      const baseURL = 'https://jjuniper-dev.github.io/hc-news-briefing-feed.github.io/';
-
-      // Load health.json and populate health table
-      try {
-        const res = await fetch(baseURL + 'health.json');
-        if (!res.ok) throw new Error(`HTTP ${res.status}`);
-        const data = await res.json();
-        const tbody = document.querySelector('#health-table tbody');
-        for (const [date, feeds] of Object.entries(data).slice(-5).reverse()) {
-          for (const [name, status] of Object.entries(feeds)) {
-            const tr = document.createElement('tr');
-            const cls = status.startsWith('ERROR') ? 'bad'
-                      : status === 'ZERO'      ? 'warn'
-                      : 'good';
-            tr.innerHTML = `
-              <td>${date}</td>
-              <td>${name}</td>
-              <td class="${cls}" title="${status}">${status}</td>
-            `;
-            tbody.appendChild(tr);
-          }
-        }
-      } catch (err) {
-        console.error('Failed to load health.json:', err);
-        const tbody = document.querySelector('#health-table tbody');
-        const tr = document.createElement('tr');
-        tr.innerHTML = `<td colspan="3" class="bad">Error loading data: ${err.message}</td>`;
-        tbody.appendChild(tr);
-      }
-
-      // Load uptime.json and compute uptime percentages
-      try {
-        const res2 = await fetch(baseURL + 'uptime.json');
-        if (!res2.ok) throw new Error(`HTTP ${res2.status}`);
-        const records = await res2.json();
-        const total = records.length;
-        const success = {};
-        // Initialize counters
-        if (total > 0) {
-          Object.keys(records[0]).filter(k => k !== 'timestamp').forEach(feed => success[feed] = 0);
-        }
-        records.forEach(r => {
-          Object.entries(r).forEach(([feed, ok]) => {
-            if (feed === 'timestamp') return;
-            if (ok) success[feed]++;
-          });
-        });
-        const ul = document.getElementById('uptime-list');
-        Object.entries(success).forEach(([feed, count]) => {
-          const pct = total ? Math.round(count / total * 100) : 0;
-          const li = document.createElement('li');
-          li.textContent = `${feed}: ${pct}% (${count}/${total} pings OK)`;
-          ul.appendChild(li);
-        });
-      } catch (err) {
-        console.error('Failed to load uptime.json:', err);
-        const ul = document.getElementById('uptime-list');
-        const li = document.createElement('li');
-        li.className = 'bad';
-        li.textContent = `Error loading uptime data: ${err.message}`;
-        ul.appendChild(li);
-      }
-    });
-  </script>
+  <footer>
+    <p>Static status pages for hc-news-briefing-feed.github.io.</p>
+  </footer>
 </body>
 </html>

--- a/latest.html
+++ b/latest.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Latest Briefing | RSS Feed Status Site</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <header>
+    <h1>RSS Feed Status Site</h1>
+    <p>Most recently generated daily briefing.</p>
+    <nav class="top-nav" aria-label="Primary">
+      <a class="nav-link" href="index.html">Overview</a>
+      <a class="nav-link" href="health.html">Health History</a>
+      <a class="nav-link" href="uptime.html">Uptime Metrics</a>
+      <a class="nav-link" href="latest.html" aria-current="page">Latest Briefing</a>
+    </nav>
+  </header>
+
+  <main>
+    <section class="card">
+      <h2>Latest Briefing</h2>
+      <p>Content loaded from <code>latest.txt</code>.</p>
+      <pre id="briefing" class="briefing-pre">Loading latest.txt...</pre>
+    </section>
+  </main>
+
+  <footer>
+    <p>Source: <code>latest.txt</code>.</p>
+  </footer>
+
+  <script>
+    document.addEventListener('DOMContentLoaded', async () => {
+      const pre = document.getElementById('briefing');
+      try {
+        const res = await fetch('./latest.txt');
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        pre.textContent = await res.text();
+      } catch (err) {
+        pre.className = 'bad';
+        pre.textContent = `Error loading latest briefing: ${err.message}`;
+      }
+    });
+  </script>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,135 @@
+:root {
+  color-scheme: light;
+  --bg: #f6f8fb;
+  --panel: #ffffff;
+  --text: #162033;
+  --muted: #4f5d75;
+  --border: #d8deea;
+  --accent: #1f6feb;
+  --good: #1a7f37;
+  --warn: #9a6700;
+  --bad: #cf222e;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: var(--text);
+  background: var(--bg);
+  line-height: 1.5;
+}
+
+header,
+main,
+footer {
+  width: min(1100px, 94vw);
+  margin-inline: auto;
+}
+
+header {
+  padding: 1.25rem 0 0.5rem;
+}
+
+h1,
+h2,
+h3 {
+  line-height: 1.2;
+  margin: 0;
+}
+
+p {
+  margin: 0;
+}
+
+.top-nav {
+  margin-top: 0.9rem;
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.nav-link {
+  text-decoration: none;
+  color: var(--accent);
+  border: 1px solid var(--border);
+  background: var(--panel);
+  padding: 0.42rem 0.78rem;
+  border-radius: 999px;
+  font-size: 0.95rem;
+}
+
+.nav-link[aria-current="page"] {
+  color: #fff;
+  background: var(--accent);
+  border-color: var(--accent);
+}
+
+main {
+  padding: 1rem 0 2rem;
+}
+
+.card {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 1rem;
+  margin-bottom: 1rem;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 1rem;
+  background: #fff;
+}
+
+th,
+td {
+  border: 1px solid var(--border);
+  padding: 0.6rem;
+  text-align: left;
+  vertical-align: top;
+}
+
+th {
+  background: #ecf2ff;
+}
+
+ul {
+  margin: 0.8rem 0 0;
+  padding-left: 1rem;
+}
+
+.good { color: var(--good); }
+.warn { color: var(--warn); }
+.bad  { color: var(--bad); }
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+  gap: 0.75rem;
+  margin-top: 0.8rem;
+}
+
+footer {
+  font-size: 0.9rem;
+  color: var(--muted);
+  padding: 0 0 1.5rem;
+}
+
+
+.briefing-pre {
+  white-space: pre-wrap;
+  word-break: break-word;
+  margin-top: 0.8rem;
+  background: #fff;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 0.8rem;
+  max-height: 65vh;
+  overflow: auto;
+}

--- a/uptime.html
+++ b/uptime.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Uptime Metrics | RSS Feed Status Site</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <header>
+    <h1>RSS Feed Status Site</h1>
+    <p>Ping reliability for Canadian feeds over the last seven days.</p>
+    <nav class="top-nav" aria-label="Primary">
+      <a class="nav-link" href="index.html">Overview</a>
+      <a class="nav-link" href="health.html">Health History</a>
+      <a class="nav-link" href="uptime.html" aria-current="page">Uptime Metrics</a>
+      <a class="nav-link" href="latest.html">Latest Briefing</a>
+    </nav>
+  </header>
+
+  <main>
+    <section class="card">
+      <h2>Uptime Metrics (past 7 days)</h2>
+      <ul id="uptime-list"></ul>
+    </section>
+  </main>
+
+  <footer>
+    <p>Source: <code>uptime.json</code>.</p>
+  </footer>
+
+  <script>
+    document.addEventListener('DOMContentLoaded', async () => {
+      const ul = document.getElementById('uptime-list');
+      try {
+        const res = await fetch('./uptime.json');
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const records = await res.json();
+        const total = records.length;
+        const success = {};
+
+        if (total > 0) {
+          Object.keys(records[0]).filter((k) => k !== 'timestamp').forEach((feed) => {
+            success[feed] = 0;
+          });
+        }
+
+        records.forEach((record) => {
+          Object.entries(record).forEach(([feed, ok]) => {
+            if (feed !== 'timestamp' && ok) success[feed] += 1;
+          });
+        });
+
+        Object.entries(success).forEach(([feed, count]) => {
+          const pct = total ? Math.round((count / total) * 100) : 0;
+          const li = document.createElement('li');
+          li.textContent = `${feed}: ${pct}% (${count}/${total} pings OK)`;
+          ul.appendChild(li);
+        });
+
+        if (Object.keys(success).length === 0) {
+          const li = document.createElement('li');
+          li.className = 'warn';
+          li.textContent = 'No uptime records were found.';
+          ul.appendChild(li);
+        }
+      } catch (err) {
+        const li = document.createElement('li');
+        li.className = 'bad';
+        li.textContent = `Error loading uptime data: ${err.message}`;
+        ul.appendChild(li);
+      }
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Provide a single, consistent status site UI with shared styling and navigation so every page is reachable and visually consistent.
- Split the original monolithic dashboard into focused pages for health history, uptime metrics, and the latest briefing to improve clarity.
- Eliminate orphan HTML pages by ensuring every page is linked from a common primary navigation.

### Description
- Introduce a shared stylesheet `styles.css` with color tokens, layout, card, table, nav and briefing styles and apply it across all pages.
- Add three dedicated pages: `health.html` (renders the last 5 days from `health.json`), `uptime.html` (computes 7-day ping percentages from `uptime.json`), and `latest.html` (loads `latest.txt` into a formatted `<pre>` element).
- Refactor `index.html` into an Overview page that links to each dedicated page and reuse the shared nav structure on every HTML file.
- Move briefing-specific CSS into the shared stylesheet and add small client-side scripts on each page to fetch the appropriate JSON/text sources.

### Testing
- Ran `rg -n 'href="[^\"]+\.html"' *.html` to list internal `.html` links and confirm expected nav entries, which returned the expected links successfully.
- Ran a Python script to verify that every `href=

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e56f1a0ca083228e4a84260ddb4176)