### PR TITLE
feat: set dashboard default source to status-site and add ?source override

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,7 @@
 <body>
   <h1>RSS Feed Health Dashboard</h1>
   <p>Showing status for the last five days (hover for details).</p>
+  <p id="status-source"></p>
   <table id="health-table">
     <thead>
       <tr><th>Date</th><th>Feed</th><th>Status</th></tr>
@@ -31,7 +32,11 @@
 
   <script>
     document.addEventListener('DOMContentLoaded', async () => {
-      const baseURL = 'https://jjuniper-dev.github.io/hc-news-briefing-feed.github.io/';
+      const defaultBaseURL = 'https://jjuniper-dev.github.io/status-site/';
+      const params = new URLSearchParams(window.location.search);
+      const sourceParam = params.get('source');
+      const baseURL = sourceParam ? sourceParam.replace(/\/?$/, '/') : defaultBaseURL;
+      document.getElementById('status-source').innerHTML = `Status source: <a href="${baseURL}" target="_blank" rel="noopener noreferrer">${baseURL}</a>`;
 
       // Load health.json and populate health table
       try {


### PR DESCRIPTION
### Motivation
- Route the dashboard to a centralized status-site so the health and uptime views use the canonical `status-site` data source rather than the repo-local site.
- Make it easy to verify and troubleshoot the data source by rendering a visible link and allowing ad-hoc overrides.

### Description
- Updated `index.html` to use `https://jjuniper-dev.github.io/status-site/` as the default `baseURL` for fetching `health.json` and `uptime.json`.
- Added a `Status source` line (`<p id="status-source">`) that displays a clickable link to the active `baseURL`.
- Added support for a `?source=` query parameter which, when provided, overrides the default URL and is normalized to include a trailing slash.
- Small DOM and fetch adjustments to continue populating the health table and uptime list from the chosen source.

### Testing
- No automated tests were executed as part of this change.
- The repository contains a GitHub Actions workflow (`.github/workflows/news_pipeline.yml`) for the pipeline but it was not triggered by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5df73539483228c9e49710e6cb275)