### PR TITLE
Add HC PPTX Builder status site and workflow artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # hc-news-briefing-feed.github.io
-Daily news briefing feed
+
+Daily news briefing feed.
+
+## HC PPTX workflow artifacts
+- Assessment: `reviews/hc-pptx-workflow-assessment.md`
+- Refactor playbook: `reviews/hc-pptx-workflow-refactor.md`
+- Compliance checklist: `reviews/hc-pptx-compliance-checklist.md`
+
+
+Web page: `status-site/pptx-builder.html`

--- a/index.html
+++ b/index.html
@@ -19,6 +19,7 @@
 <body>
   <h1>RSS Feed Health Dashboard</h1>
   <p>Showing status for the last five days (hover for details).</p>
+  <p><a href="status-site/pptx-builder.html">Open HC PPTX Builder workflow</a></p>
   <table id="health-table">
     <thead>
       <tr><th>Date</th><th>Feed</th><th>Status</th></tr>

--- a/pptx-builder.html
+++ b/pptx-builder.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>PPTX Builder moved</title>
+  <meta http-equiv="refresh" content="0; url=status-site/pptx-builder.html" />
+</head>
+<body>
+  <p>This page moved to <a href="status-site/pptx-builder.html">status-site/pptx-builder.html</a>.</p>
+</body>
+</html>

--- a/reviews/hc-pptx-compliance-checklist.md
+++ b/reviews/hc-pptx-compliance-checklist.md
@@ -1,0 +1,32 @@
+# HC PPTX Compliance Checklist
+
+Use this checklist before deck sign-off.
+
+## Source and Data Integrity
+- [ ] Every numeric claim maps to a source range.
+- [ ] All units, currencies, and time windows are explicit.
+- [ ] As-of date is shown for data freshness.
+- [ ] Any estimates/assumptions are labeled.
+
+## Narrative Quality
+- [ ] Every slide has a clear decision-oriented message title.
+- [ ] Evidence supports message without contradiction.
+- [ ] Slides are ordered as: context -> insight -> implication -> action.
+
+## HC Design Standards
+- [ ] Approved HC master/template used.
+- [ ] Typography and spacing match HC rules.
+- [ ] Color usage follows HC palette and semantics.
+- [ ] Footer includes source citation and date.
+
+## Accessibility
+- [ ] Minimum readable font size met.
+- [ ] Color contrast is sufficient.
+- [ ] Dense visuals have explanatory labels or notes.
+- [ ] Alt text policy followed where required.
+
+## QA Closure
+- [ ] Content QA passed.
+- [ ] Visual QA passed.
+- [ ] Open issues resolved or accepted with owner sign-off.
+- [ ] Final compliance summary attached.

--- a/reviews/hc-pptx-workflow-assessment.md
+++ b/reviews/hc-pptx-workflow-assessment.md
@@ -1,0 +1,64 @@
+# HC PPTX Workflow Assessment
+
+## Objective
+Create a repeatable workflow that uses Claude's Excel + PowerPoint shared context capability while enforcing HC standards before delivery.
+
+## Current-State Risks (typical)
+1. **Linear handoff workflow**: data extraction, story drafting, slide building, and QA happen in separate passes.
+2. **No explicit quality gates**: compliance checks happen late, usually after visual build is complete.
+3. **Weak traceability**: insights in slides are not always linked to source-table locations or refresh timestamps.
+4. **Manual formatting drift**: recurring decks gradually diverge from HC design standards.
+5. **Single-pass generation**: generated content is accepted without extract-and-verify loops.
+
+## Target-State Architecture
+
+### Stage 1 — Inputs and Constraints
+- Define objective, audience, decision required, and time horizon.
+- Pin source workbook tabs/ranges and refresh timestamp.
+- Load HC standard constraints (tone, typography, layout, citation, accessibility).
+
+### Stage 2 — Insight Extraction in Excel
+- Ask Claude to extract KPIs, trends, anomalies, and deltas from specified ranges.
+- Require a table with: `insight`, `value`, `source_cell_range`, `confidence_note`.
+- Flag assumptions and missing data explicitly.
+
+### Stage 3 — Narrative Blueprint
+- Convert insights into a slide-by-slide outline:
+  - slide objective
+  - audience takeaway
+  - evidence and chart type
+  - action/decision statement
+
+### Stage 4 — Deck Build in PowerPoint
+- Build from approved HC template/master.
+- Keep one message per slide and one primary visual per message.
+- Auto-insert source + date footers from extracted ranges.
+
+### Stage 5 — Two-Layer QA (Required)
+1. **Content QA**
+   - Extract slide text and compare metrics against source ranges.
+   - Check every claim has a citation and timestamp.
+2. **Visual QA**
+   - Render slides to images and inspect overlap, truncation, color contrast, and alignment.
+   - Enforce HC accessibility checks (font size floors, contrast, alt text rules where required).
+
+### Stage 6 — Remediation Loop
+- Fix violations.
+- Re-run both QA layers.
+- Produce a final compliance summary for sign-off.
+
+## Maturity Scorecard
+Use this 0–3 scoring model (0 = absent, 3 = fully automated):
+- Source traceability
+- Standards enforcement
+- Accessibility enforcement
+- Reusability of templates/components
+- QA automation depth
+- Auditability/sign-off readiness
+
+## Definition of Done
+A deck is only complete when:
+- all claims trace to source ranges,
+- all HC checks pass,
+- no visual defects remain,
+- and a compliance summary is attached.

--- a/reviews/hc-pptx-workflow-refactor.md
+++ b/reviews/hc-pptx-workflow-refactor.md
@@ -1,0 +1,73 @@
+# HC PPTX Workflow Refactor Playbook
+
+## 1) Refactor Goals
+- Reduce manual copy/paste between Excel and PowerPoint.
+- Enforce HC standards as **gates**, not post-hoc review notes.
+- Make every slide auditable.
+
+## 2) Refactored Operating Model
+
+### Gate A — Brief Intake (mandatory)
+Required fields:
+- audience
+- objective
+- decision requested
+- timeframe
+- source workbook + tabs + ranges
+- delivery deadline
+
+### Gate B — Insight Contract (mandatory)
+Claude output must include:
+- KPI values
+- trend direction
+- outlier explanation
+- source range for each metric
+- known limitations
+
+Reject output if source ranges are missing.
+
+### Gate C — Story Contract (mandatory)
+Each planned slide must include:
+- message title (assertive statement)
+- evidence list
+- chart/table type
+- desired executive action
+
+Reject if message is descriptive but not decision-oriented.
+
+### Gate D — Build Contract (mandatory)
+PowerPoint build rules:
+- must use HC template master
+- max one core claim per slide
+- footer contains source and as-of date
+- avoid decorative visuals without analytical purpose
+
+### Gate E — QA Contract (mandatory)
+- Content QA pass: metrics, labels, dates, units
+- Visual QA pass: overlap, overflow, contrast, alignment, consistency
+- Accessibility pass: minimum font sizes, readable color pairs, alt text policy
+
+## 3) Prompt/Instruction Patterns to Standardize
+
+### Excel analysis prompt pattern
+"Analyze ranges [X] for [objective]. Return KPI table with values, deltas, and `source_cell_range` per KPI. Highlight anomalies and confidence notes."
+
+### Story synthesis prompt pattern
+"Create a decision-oriented slide plan from this KPI table. For each slide provide: title, key takeaway, evidence, chart type, and action."
+
+### Deck build prompt pattern
+"Build slides using HC template constraints: typography, spacing, footer citations, and accessibility requirements."
+
+### QA prompt pattern
+"Perform compliance QA against HC checklist. Return only violations with severity, slide number, fix, and recheck status."
+
+## 4) KPI Targets After Refactor
+- 30–50% reduction in deck production cycle time.
+- 90%+ first-pass compliance on HC formatting standards.
+- 100% source traceability for numeric claims.
+
+## 5) Rollout Plan
+1. Pilot on one recurring weekly deck.
+2. Measure baseline vs refactored cycle time and defect rate.
+3. Codify exceptions into checklist.
+4. Expand to all briefing decks.

--- a/status-site/pptx-builder.html
+++ b/status-site/pptx-builder.html
@@ -1,0 +1,156 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Status Site • PPTX Builder</title>
+  <style>
+    :root {
+      --bg: #0b1020;
+      --panel: #121933;
+      --panel-2: #192241;
+      --text: #eef2ff;
+      --muted: #b8c1e8;
+      --accent: #67e8f9;
+      --accent-2: #22c55e;
+      --warn: #f97316;
+      --border: #2a3768;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      background: var(--bg);
+      color: var(--text);
+      font-family: Inter, system-ui, -apple-system, Segoe UI, sans-serif;
+      line-height: 1.5;
+    }
+    header {
+      position: sticky;
+      top: 0;
+      z-index: 10;
+      background: rgba(11,16,32,0.95);
+      backdrop-filter: blur(4px);
+      border-bottom: 1px solid var(--border);
+      padding: 0.8rem 1rem;
+    }
+    .nav { display: flex; gap: 1rem; flex-wrap: wrap; }
+    .nav a {
+      color: var(--muted);
+      text-decoration: none;
+      font-size: 0.95rem;
+    }
+    .nav a.active, .nav a:hover { color: var(--accent); }
+    main { max-width: 1100px; margin: 1.2rem auto; padding: 0 1rem 2rem; }
+    .hero, .panel {
+      background: var(--panel);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 1rem 1.1rem;
+      margin-bottom: 1rem;
+    }
+    h1, h2, h3 { margin: 0.2rem 0 0.7rem; }
+    .muted { color: var(--muted); }
+    .pill {
+      display: inline-block;
+      padding: 0.2rem 0.6rem;
+      border: 1px solid var(--border);
+      border-radius: 999px;
+      color: var(--accent);
+      font-size: 0.8rem;
+      margin-bottom: 0.5rem;
+    }
+    .grid { display: grid; gap: 0.8rem; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); }
+    .card {
+      background: var(--panel-2);
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      padding: 0.8rem;
+    }
+    .gate { border-left: 4px solid var(--accent-2); }
+    .checklist label { display: block; margin-bottom: 0.45rem; }
+    code {
+      display: inline-block;
+      background: #0e1530;
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      padding: 0.25rem 0.4rem;
+      margin-top: 0.3rem;
+      color: #dbeafe;
+    }
+    .warning {
+      border-left: 4px solid var(--warn);
+      color: #fed7aa;
+      background: #3a1f14;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <nav class="nav" aria-label="Primary">
+      <a href="/status-site/index.html">Dashboard</a>
+      <a href="/status-site/decisions.html">Decisions</a>
+      <a href="/status-site/scenarios.html">Scenarios</a>
+      <a href="/status-site/intelligence.html">Intelligence</a>
+      <a href="/status-site/artifacts.html">Artifacts</a>
+      <a href="/status-site/architecture.html">Architecture</a>
+      <a href="/status-site/control-plane.html">Control Plane</a>
+      <a href="/status-site/pptx-builder.html" class="active">PPTX</a>
+    </nav>
+  </header>
+
+  <main>
+    <section class="hero">
+      <span class="pill">HC PPTX BUILDER • v2</span>
+      <h1>Integrated Excel ↔ PowerPoint Workflow</h1>
+      <p class="muted">This page replaces the old PPTX workflow with a gated, compliance-first flow aligned to HC standards.</p>
+      <p class="muted">Artifacts: <a href="/hc-news-briefing-feed.github.io/reviews/hc-pptx-workflow-assessment.md">Assessment</a> · <a href="/hc-news-briefing-feed.github.io/reviews/hc-pptx-workflow-refactor.md">Refactor</a> · <a href="/hc-news-briefing-feed.github.io/reviews/hc-pptx-compliance-checklist.md">Checklist</a></p>
+    </section>
+
+    <section class="panel">
+      <h2>Mandatory Gates</h2>
+      <div class="grid">
+        <div class="card gate"><h3>Gate A · Intake</h3><p class="muted">Audience, objective, decision, timeframe, workbook tabs/ranges, deadline.</p></div>
+        <div class="card gate"><h3>Gate B · Insight Contract</h3><p class="muted">KPI values + trends + outliers + source ranges + limitations.</p></div>
+        <div class="card gate"><h3>Gate C · Story Contract</h3><p class="muted">Decision title, evidence, chart type, and required action per slide.</p></div>
+        <div class="card gate"><h3>Gate D · Build Contract</h3><p class="muted">HC template, one claim per slide, source and as-of footer.</p></div>
+        <div class="card gate"><h3>Gate E · QA Contract</h3><p class="muted">Content QA + visual QA + accessibility QA with remediation loop.</p></div>
+      </div>
+    </section>
+
+    <section class="panel">
+      <h2>Prompt Pack</h2>
+      <div class="grid">
+        <div class="card">
+          <h3>Excel Extraction</h3>
+          <p class="muted">Generate traceable KPI outputs.</p>
+          <code>Return KPI table with value, delta, source_cell_range, confidence_note.</code>
+        </div>
+        <div class="card">
+          <h3>Story Build</h3>
+          <p class="muted">Force decision orientation on each slide.</p>
+          <code>For each slide: title, takeaway, evidence, chart, action.</code>
+        </div>
+        <div class="card">
+          <h3>QA Sweep</h3>
+          <p class="muted">Return violations only, with severity and fix.</p>
+          <code>List issues by slide with severity, remediation, and recheck.</code>
+        </div>
+      </div>
+    </section>
+
+    <section class="panel checklist">
+      <h2>Fast Compliance Checklist</h2>
+      <label><input type="checkbox"> Every number maps to source range.</label>
+      <label><input type="checkbox"> Units and as-of dates are explicit.</label>
+      <label><input type="checkbox"> HC template, spacing, and palette are compliant.</label>
+      <label><input type="checkbox"> Font/contrast accessibility checks pass.</label>
+      <label><input type="checkbox"> Visual QA passes (no overlap/truncation).</label>
+      <label><input type="checkbox"> Final compliance summary attached.</label>
+    </section>
+
+    <section class="panel warning">
+      <strong>Release rule:</strong> do not publish deck outputs until all gates are complete and QA issues are closed.
+    </section>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Provide a gated, compliance-first PPTX workflow and make related artifacts discoverable from the project landing pages.
- Surface the new PPTX Builder status page from the RSS Feed Health Dashboard for quick access.

### Description
- Add three workflow artifacts as markdown under `reviews/`: `hc-pptx-workflow-assessment.md`, `hc-pptx-workflow-refactor.md`, and `hc-pptx-compliance-checklist.md` documenting goals, gates, prompt patterns, and a compliance checklist.
- Introduce a dedicated status site page at `status-site/pptx-builder.html` that presents the gated workflow, prompt pack, and a fast compliance checklist with styling and navigation.
- Provide a small compatibility redirect page `pptx-builder.html` that points to `status-site/pptx-builder.html` and add a link to that page from the main `index.html` dashboard.
- Update `README.md` to reference the new HC PPTX workflow artifacts and the web page `status-site/pptx-builder.html`.

### Testing
- No automated tests were run against these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e644e7e2b08322be05511e49a61911)