### PR TITLE
Add intelligence posts page and editor workflow/template with dashboard links

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,10 +22,12 @@
 <body>
   <h1>RSS Feed Health Dashboard</h1>
   <p><a href="intelligence-editor.html">Open Intelligence Editor</a></p>
+  <p><a href="status-site/intelligence.html">Open Intelligence Posts</a></p>
   <p>Showing status for the last five days (hover for details).</p>
   <p><a href="status-site/pptx-builder.html">Open HC PPTX Builder workflow</a></p>
   <nav class="site-nav" aria-label="Site navigation">
     <a href="index.html">Dashboard</a>
+    <a href="status-site/intelligence.html">Intelligence Posts</a>
     <a href="status-site/pptx-builder.html">PPTX Builder</a>
     <a href="reviews/hc-pptx-workflow-assessment.md">Assessment</a>
     <a href="reviews/hc-pptx-workflow-refactor.md">Refactor</a>

--- a/intelligence-editor.bootstrap.js
+++ b/intelligence-editor.bootstrap.js
@@ -1,4 +1,47 @@
 (function bootstrapIntelligenceEditor() {
+  const CANCHAT_TEMPLATE = `# CANChat — Intelligence Brief
+Date: 2026-04-21
+Update Type: operational-signal
+Version: v0.1
+Change Log:
+- Initial draft in intelligence editor
+
+## Executive Signal
+CANChat is not an AI platform in the enterprise architecture sense. It is a multi-model workforce interface delivered by SSC.
+
+The Government of Canada–owned model ("GC LLM") is accessible within CANChat, but not exposed as a department-consumable API endpoint based on current public evidence.
+
+## Core Clarification (Critical)
+| Concept | What it is | What it is not |
+|--------|------------|----------------|
+| CANChat | SSC-delivered chatbot service (UI layer) | Not a reusable AI runtime platform |
+| GC LLM | GC-tuned model (Llama-based) inside CANChat | Not an exposed API or standalone service |
+| Model Access | Interactive (user-facing) | Not programmatic (no confirmed endpoint) |
+
+## Current Capability (Observed)
+- Multi-model access (Cohere, OpenAI, Gemini, GC LLM, etc.)
+- Delivered via browser-based chatbot interface
+- Identity integrated via GC credentials (Entra ID via SSC)
+- Designed for employee productivity use cases
+
+### Key Limitation
+No confirmed public pattern for API access, service-to-service integration, or embedding GC LLM into applications.
+
+## EA Interpretation
+### What this means
+- SSC is moving from tool (chat interface) toward platform (enterprise AI capability).
+- Future state likely includes Protected B support, broader integration, and standardized service patterns.
+
+### What this does NOT mean (yet)
+- GC LLM availability via API is not confirmed.
+- Departments cannot assume direct app integration capability.
+- CANChat does not replace PATH/runtime control plane.
+
+## Bottom Line
+CANChat is where users interact with AI today.
+It is not yet how systems integrate AI.
+`;
+
   class MarkdownProcessor {
     constructor(previewSelector) {
       this.preview = document.querySelector(previewSelector);
@@ -71,6 +114,11 @@
 
     const editorElement = document.querySelector('#intelligence-markdown-editor');
     const previewButton = document.querySelector('#btn-preview');
+    const loadTemplateButton = document.querySelector('#btn-load-canchat-template');
+    const updateTypeSelect = document.querySelector('#update-type');
+    const briefDateInput = document.querySelector('#brief-date');
+    const versionInput = document.querySelector('#brief-version');
+    const changeLogInput = document.querySelector('#change-log');
 
     if (!editorElement || !window.IntelligenceEditor) {
       console.warn('Intelligence editor prerequisites not found.');
@@ -86,6 +134,41 @@
     });
 
     intelligenceEditor.init();
+
+    if (briefDateInput && !briefDateInput.value) {
+      briefDateInput.value = new Date().toISOString().slice(0, 10);
+    }
+
+    if (!editorElement.value.trim()) {
+      editorElement.value = CANCHAT_TEMPLATE;
+    }
+
+    const syncHeaderFields = () => {
+      const text = editorElement.value;
+      const nextDate = briefDateInput?.value || '';
+      const nextType = updateTypeSelect?.value || '';
+      const nextVersion = versionInput?.value || '';
+      const nextLog = changeLogInput?.value || '- Initial draft in intelligence editor';
+
+      const updated = text
+        .replace(/^Date:\s.*$/m, `Date: ${nextDate}`)
+        .replace(/^Update Type:\s.*$/m, `Update Type: ${nextType}`)
+        .replace(/^Version:\s.*$/m, `Version: ${nextVersion}`)
+        .replace(/(^Change Log:\n)(?:-.*\n)?/m, `$1${nextLog.split('\n').map((line) => line.trim() || '-').join('\n')}\n`);
+
+      editorElement.value = updated;
+      markdownProcessor.process(editorElement.value);
+    };
+
+    loadTemplateButton?.addEventListener('click', () => {
+      editorElement.value = CANCHAT_TEMPLATE;
+      syncHeaderFields();
+      markdownProcessor.process(editorElement.value);
+    });
+    updateTypeSelect?.addEventListener('change', syncHeaderFields);
+    briefDateInput?.addEventListener('change', syncHeaderFields);
+    versionInput?.addEventListener('input', syncHeaderFields);
+    changeLogInput?.addEventListener('input', syncHeaderFields);
 
     editorElement.addEventListener('input', () => markdownProcessor.process(editorElement.value));
     previewButton?.addEventListener('click', () => markdownProcessor.process(editorElement.value));

--- a/intelligence-editor.css
+++ b/intelligence-editor.css
@@ -28,6 +28,7 @@ body {
   color: var(--brand);
   text-decoration: none;
 }
+.muted { color: #475569; }
 
 .editor-card,
 .review-card {
@@ -61,8 +62,29 @@ body {
   grid-template-columns: 1fr 1fr;
 }
 
+.workflow-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: 1fr 1fr;
+}
+
+.workflow-input {
+  width: 100%;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: .45rem .5rem;
+  margin: .25rem 0 .6rem;
+  font: inherit;
+}
+
+.workflow-list {
+  margin-top: .25rem;
+  padding-left: 1.1rem;
+}
+
 @media (max-width: 900px) {
   .editor-grid { grid-template-columns: 1fr; }
+  .workflow-grid { grid-template-columns: 1fr; }
 }
 
 .markdown-input,

--- a/intelligence-editor.html
+++ b/intelligence-editor.html
@@ -12,11 +12,51 @@
       <h1>Intelligence Editor</h1>
       <p>Draft intelligence updates, import source files, and review AI-assisted findings.</p>
       <a href="index.html">← Back to dashboard</a>
+      <span class="muted"> · </span>
+      <a href="status-site/intelligence.html">View intelligence posts</a>
     </header>
+
+    <section class="editor-card" aria-label="Intelligence workflow">
+      <h2>Intelligence workflow</h2>
+      <p class="muted">CLAUDE.md was not found in this repository, so this editor includes the required operational workflow directly.</p>
+      <div class="workflow-grid">
+        <div class="panel">
+          <h3>1) Classify update type</h3>
+          <label for="update-type">Update type</label>
+          <select id="update-type" class="workflow-input">
+            <option value="operational-signal">Operational signal</option>
+            <option value="capability-gap">Capability gap</option>
+            <option value="capability-update">Capability update</option>
+            <option value="risk-watch">Risk / watch item</option>
+          </select>
+        </div>
+        <div class="panel">
+          <h3>2) Versioning and log</h3>
+          <label for="brief-date">Brief date</label>
+          <input id="brief-date" class="workflow-input" type="date" />
+          <label for="brief-version">Version</label>
+          <input id="brief-version" class="workflow-input" type="text" value="v0.1" />
+          <label for="change-log">Change log</label>
+          <textarea id="change-log" class="workflow-input" rows="3" placeholder="- Initial draft created"></textarea>
+        </div>
+      </div>
+      <h3>3) Required 7-step flow</h3>
+      <ol class="workflow-list">
+        <li>Draft in editor (markdown).</li>
+        <li>Analyze with local LLM review.</li>
+        <li>Publish to <code>intelligence-draft</code> branch.</li>
+        <li>Update date, version, and change log.</li>
+        <li>Check quality standards (clarity, evidence, traceability).</li>
+        <li>Apply tone guidelines (briefing-ready, neutral, decision-oriented).</li>
+        <li>Compare with similar examples before finalizing.</li>
+      </ol>
+      <p class="muted">Examples in repo: <code>content/assessments/cohere/v0.1/assessment.md</code> and <code>reviews/hc-pptx-workflow-assessment.md</code>.</p>
+    </section>
 
     <section class="editor-card" aria-label="Intelligence editor">
       <div id="intelligence-toolbar" class="toolbar">
         <button type="button" id="btn-preview" title="Refresh preview">🔄 Preview</button>
+        <button type="button" id="btn-load-canchat-template" title="Load CANChat briefing template">🧩 Load CANChat Template</button>
       </div>
 
       <div class="editor-grid">

--- a/status-site/intelligence.html
+++ b/status-site/intelligence.html
@@ -1,0 +1,141 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Intelligence Briefing Feed</title>
+  <style>
+    :root {
+      --bg: #f8fafc;
+      --panel: #fff;
+      --text: #111827;
+      --muted: #4b5563;
+      --border: #d1d5db;
+      --brand: #0f766e;
+      --alert: #7f1d1d;
+      --alert-bg: #fee2e2;
+    }
+    body {
+      margin: 0;
+      font-family: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      background: var(--bg);
+      color: var(--text);
+      line-height: 1.55;
+    }
+    header {
+      background: var(--panel);
+      border-bottom: 1px solid var(--border);
+      padding: 1rem 1.5rem;
+    }
+    .nav a {
+      color: var(--brand);
+      text-decoration: none;
+      margin-right: 1rem;
+      font-weight: 600;
+    }
+    main {
+      max-width: 1000px;
+      margin: 1.25rem auto;
+      padding: 0 1rem 2rem;
+    }
+    .post {
+      background: var(--panel);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 1rem 1.2rem;
+      margin-bottom: 1rem;
+    }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      margin-top: .75rem;
+    }
+    th, td {
+      border: 1px solid var(--border);
+      padding: .5rem;
+      text-align: left;
+      vertical-align: top;
+    }
+    th { background: #f1f5f9; }
+    .muted { color: var(--muted); }
+    .alert {
+      border-left: 4px solid var(--alert);
+      background: var(--alert-bg);
+      padding: .75rem;
+      border-radius: 8px;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <nav class="nav" aria-label="Site navigation">
+      <a href="../index.html">Dashboard</a>
+      <a href="../intelligence-editor.html">Intelligence Editor</a>
+      <a href="../status-site/intelligence.html">Intelligence Posts</a>
+      <a href="../status-site/pptx-builder.html">PPTX Builder</a>
+    </nav>
+  </header>
+
+  <main>
+    <section class="post">
+      <h1>Intelligence Briefing Feed</h1>
+      <p class="muted">Published intelligence notes are tracked as dated items below. New updates should be appended as additional feed items.</p>
+      <table>
+        <thead>
+          <tr>
+            <th>Date</th>
+            <th>Item</th>
+            <th>Type</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>2026-04-22</td>
+            <td><a href="#item-path-hail-convergence">PATH/HAIL Convergence — Framing Correction</a></td>
+            <td>Operational signal / governance gap</td>
+          </tr>
+          <tr>
+            <td>2026-04-21</td>
+            <td><a href="#item-canchat-positioning">CANChat positioning and platform-gap clarification</a></td>
+            <td>Capability interpretation / strategic alignment</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <article class="post" id="item-path-hail-convergence">
+      <h2>PATH/HAIL Convergence — Framing Correction</h2>
+      <p class="muted"><strong>Date:</strong> 2026-04-22 · <strong>Type:</strong> Operational signal / governance gap</p>
+
+      <h2>Executive Signal</h2>
+      <p>The current “customer one, customer two” language creates a false production signal for PATH and obscures the actual enterprise architecture issue.</p>
+
+      <h2>What is going wrong</h2>
+      <ul>
+        <li><strong>Language risk:</strong> “Customer” implies PATH is already an operational service with near-term production onboarding.</li>
+        <li><strong>Architecture risk:</strong> That framing hides the unresolved PATH/HAIL convergence model and shifts attention away from runtime governance.</li>
+      </ul>
+
+      <h2>Core unresolved question</h2>
+      <p>When workloads move from PATH execution patterns into production runtime, what governs the transition, which environment hosts it, who owns operations, and how are governance controls shared or de-duplicated across PATH and HAIL?</p>
+
+      <h2>Risk if framing is not corrected</h2>
+      <div class="alert">
+        PMRA can become a de facto production workload under an informal model before convergence architecture and operating governance are formally defined.
+      </div>
+
+      <h2>Required leadership framing (ARB + director level)</h2>
+      <p>PATH and HAIL are not competing services. They are components of one enterprise AI platform that is not yet formally unified. Until convergence architecture and operating model governance are established, no workload should be treated as production regardless of pattern. PMRA should be treated as a design input, not a production customer.</p>
+
+      <h2>Bottom line</h2>
+      <p>Reframe the discussion from “customer onboarding” to “convergence and operating model governance” before additional workloads attach implicit production expectations.</p>
+    </article>
+
+    <article class="post" id="item-canchat-positioning">
+      <h2>CANChat positioning and platform-gap clarification</h2>
+      <p class="muted"><strong>Date:</strong> 2026-04-21 · <strong>Type:</strong> Capability interpretation / strategic alignment</p>
+      <p>CANChat should be treated as a workforce productivity interface, not as an enterprise runtime platform or integration control plane. The key architecture gap remains governed runtime and API-first integration patterns.</p>
+    </article>
+  </main>
+</body>
+</html>

--- a/status-site/pptx-builder.html
+++ b/status-site/pptx-builder.html
@@ -88,6 +88,7 @@
   <header>
     <nav class="nav" aria-label="Site navigation">
       <a href="../index.html">Dashboard</a>
+      <a href="../status-site/intelligence.html">Intelligence Posts</a>
       <a href="../pptx-builder.html">PPTX Builder</a>
       <a href="../reviews/hc-pptx-workflow-assessment.md">Assessment</a>
       <a href="../reviews/hc-pptx-workflow-refactor.md">Refactor</a>


### PR DESCRIPTION
### Motivation
- Provide a lightweight public feed for published intelligence notes and make them discoverable from the dashboard. 
- Improve the Intelligence Editor UX by embedding a required operational workflow, metadata fields, and a reusable briefing template. 
- Ensure authors can quickly load and synchronize header fields (date/type/version/change log) into markdown for consistent publishing.

### Description
- Added a new status page at `status-site/intelligence.html` with sample briefing items and detailed posts for published intelligence notes. 
- Updated `index.html` and `status-site/pptx-builder.html` to surface links to the new Intelligence Posts page in the dashboard and nav bars. 
- Extended the editor UI in `intelligence-editor.html` to include a workflow panel, metadata inputs (`#update-type`, `#brief-date`, `#brief-version`, `#change-log`), a `Load CANChat Template` button, and inline guidance. 
- Implemented the template and sync behavior in `intelligence-editor.bootstrap.js` by adding `CANCHAT_TEMPLATE`, default population logic, `syncHeaderFields` to keep header metadata in sync, and event handlers to load/sync the template; added small layout and component styles in `intelligence-editor.css` (`.muted`, `.workflow-grid`, `.workflow-input`, `.workflow-list`).

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7d7ab39088322962c5e490dcd76a7)