### PR TITLE
Add lightweight automated test plan for GitHub Pages site

### DIFF
--- a/.github/workflows/site-test-plan.yml
+++ b/.github/workflows/site-test-plan.yml
@@ -1,0 +1,57 @@
+name: Site Test Plan
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  content-integrity:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Lint Markdown
+        uses: DavidAnson/markdownlint-cli2-action@v20
+        with:
+          globs: |
+            **/*.md
+      - name: Check links in docs and pages
+        uses: lycheeverse/lychee-action@v2
+        with:
+          fail: true
+          args: >-
+            --no-progress
+            --retry-wait-time 2
+            --max-retries 2
+            --accept 200,206,301,302,403,429
+            README.md docs/**/*.md reviews/**/*.md index.html
+
+  static-quality:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Functional smoke checks
+        run: python scripts/test_functional.py
+      - name: Accessibility baseline checks
+        run: python scripts/test_accessibility.py
+      - name: Performance budget checks
+        run: python scripts/test_performance_budget.py
+
+  security-headers:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Validate deployed headers (GitHub Pages)
+        env:
+          SITE_URL: ${{ format('https://{0}.github.io/{1}/', github.repository_owner, github.event.repository.name) }}
+        run: python scripts/check_security_headers.py

--- a/docs/test-plan-implementation.md
+++ b/docs/test-plan-implementation.md
@@ -1,0 +1,50 @@
+# Site Test Plan Implementation (Automation + GitHub Pages)
+
+This repository now includes a lightweight test strategy designed for GitHub Pages and focused on small, secure checks.
+
+## 1) Functional smoke checks
+- File: `scripts/test_functional.py`
+- Validates:
+  - Core public pages exist.
+  - Internal links in `index.html` resolve.
+  - A warning is raised when no custom `404.html` exists.
+
+## 2) Accessibility baseline checks
+- File: `scripts/test_accessibility.py`
+- Runs static accessibility checks for key pages:
+  - `<html lang>` exists.
+  - Non-empty `<title>` exists.
+  - All `<img>` tags include `alt`.
+
+## 3) Security header checks
+- File: `scripts/check_security_headers.py`
+- Runs against deployed GitHub Pages URL (`SITE_URL`) and enforces required baseline headers:
+  - `Strict-Transport-Security`
+  - `X-Content-Type-Options`
+- Reports missing recommended headers as warnings.
+
+## 4) Performance budget checks
+- File: `scripts/test_performance_budget.py`
+- Enforces a small static-site budget:
+  - Max single tracked asset size.
+  - Max total tracked HTML/CSS/JS/JSON size.
+
+## 5) Content integrity checks
+- Markdown linting with `markdownlint-cli2`.
+- Link validation with `lychee` over docs/reviews/site entry files.
+
+## 6) CI orchestration in GitHub Actions
+- Workflow file: `.github/workflows/site-test-plan.yml`
+- Triggered on pull requests and pushes to `main`.
+- Jobs are split by concern:
+  - `content-integrity`
+  - `static-quality`
+  - `security-headers`
+
+## Local developer commands
+```bash
+python scripts/test_functional.py
+python scripts/test_accessibility.py
+python scripts/test_performance_budget.py
+SITE_URL="https://<org>.github.io/<repo>/" python scripts/check_security_headers.py
+```

--- a/scripts/check_security_headers.py
+++ b/scripts/check_security_headers.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Minimal HTTP response header checks for a deployed GitHub Pages site."""
+
+from __future__ import annotations
+
+import os
+import sys
+from urllib.error import URLError, HTTPError
+from urllib.request import Request, urlopen
+
+SITE_URL = os.environ.get("SITE_URL", "").strip()
+TIMEOUT_SECONDS = 20
+
+REQUIRED_HEADERS = {
+    "strict-transport-security": "max-age",
+    "x-content-type-options": "nosniff",
+}
+
+RECOMMENDED_HEADERS = [
+    "content-security-policy",
+    "x-frame-options",
+    "referrer-policy",
+]
+
+if not SITE_URL:
+    print("SITE_URL is not set; skipping deployed header checks.")
+    sys.exit(0)
+
+request = Request(SITE_URL, headers={"User-Agent": "hc-site-security-check/1.0"})
+
+try:
+    with urlopen(request, timeout=TIMEOUT_SECONDS) as response:
+        status_code = response.getcode()
+        headers = {k.lower(): v.lower() for k, v in response.headers.items()}
+except HTTPError as exc:
+    print(f"Target returned HTTP {exc.code}: {SITE_URL}")
+    sys.exit(1)
+except URLError as exc:
+    print(f"Failed to fetch {SITE_URL}: {exc}")
+    sys.exit(1)
+
+if status_code >= 400:
+    print(f"Target returned HTTP {status_code}: {SITE_URL}")
+    sys.exit(1)
+
+missing_required = []
+for header, expected in REQUIRED_HEADERS.items():
+    value = headers.get(header)
+    if not value or expected not in value:
+        missing_required.append((header, expected, value))
+
+if missing_required:
+    print("Missing required security headers:")
+    for header, expected, actual in missing_required:
+        print(f"- {header} (expected to include '{expected}', got: {actual!r})")
+    sys.exit(1)
+
+print("Required security headers are present.")
+
+for header in RECOMMENDED_HEADERS:
+    if header not in headers:
+        print(f"Warning: recommended header is missing: {header}")

--- a/scripts/test_accessibility.py
+++ b/scripts/test_accessibility.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Basic accessibility lint for key static pages."""
+
+from __future__ import annotations
+
+from html.parser import HTMLParser
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PAGES = [
+    ROOT / "index.html",
+    ROOT / "intelligence-editor.html",
+    ROOT / "status-site" / "intelligence.html",
+    ROOT / "status-site" / "pptx-builder.html",
+]
+
+
+class AccessibilityParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self.has_title = False
+        self.title_text = ""
+        self.capture_title = False
+        self.html_lang = ""
+        self.images_missing_alt = 0
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        tag_name = tag.lower()
+        attr_map = {k.lower(): (v or "") for k, v in attrs}
+        if tag_name == "html":
+            self.html_lang = attr_map.get("lang", "").strip()
+        elif tag_name == "title":
+            self.has_title = True
+            self.capture_title = True
+        elif tag_name == "img" and "alt" not in attr_map:
+            self.images_missing_alt += 1
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag.lower() == "title":
+            self.capture_title = False
+
+    def handle_data(self, data: str) -> None:
+        if self.capture_title:
+            self.title_text += data
+
+
+errors: list[str] = []
+
+for page in PAGES:
+    if not page.exists():
+        errors.append(f"Missing page for accessibility check: {page.relative_to(ROOT)}")
+        continue
+
+    parser = AccessibilityParser()
+    parser.feed(page.read_text(encoding="utf-8"))
+
+    if not parser.html_lang:
+        errors.append(f"{page.relative_to(ROOT)}: missing <html lang=...>")
+    if not parser.has_title or not parser.title_text.strip():
+        errors.append(f"{page.relative_to(ROOT)}: missing non-empty <title>")
+    if parser.images_missing_alt > 0:
+        errors.append(
+            f"{page.relative_to(ROOT)}: {parser.images_missing_alt} <img> tag(s) missing alt attribute"
+        )
+
+if errors:
+    print("Accessibility checks failed:")
+    for err in errors:
+        print(f"- {err}")
+    raise SystemExit(1)
+
+print("Accessibility checks passed.")

--- a/scripts/test_functional.py
+++ b/scripts/test_functional.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Small functional checks for static GitHub Pages content."""
+
+from __future__ import annotations
+
+from html.parser import HTMLParser
+from pathlib import Path
+from urllib.parse import urlparse
+
+ROOT = Path(__file__).resolve().parents[1]
+INDEX = ROOT / "index.html"
+REQUIRED_FILES = [
+    ROOT / "index.html",
+    ROOT / "intelligence-editor.html",
+    ROOT / "status-site" / "intelligence.html",
+    ROOT / "status-site" / "pptx-builder.html",
+]
+
+
+class LinkParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self.links: list[str] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if tag.lower() != "a":
+            return
+        for key, value in attrs:
+            if key.lower() == "href" and value:
+                self.links.append(value.strip())
+
+
+errors: list[str] = []
+warnings: list[str] = []
+
+for file_path in REQUIRED_FILES:
+    if not file_path.exists():
+        errors.append(f"Missing required page: {file_path.relative_to(ROOT)}")
+
+if INDEX.exists():
+    parser = LinkParser()
+    parser.feed(INDEX.read_text(encoding="utf-8"))
+
+    for href in parser.links:
+        if not href or href.startswith("#"):
+            continue
+
+        parsed = urlparse(href)
+        if parsed.scheme in {"http", "https"}:
+            continue
+
+        candidate = (ROOT / parsed.path).resolve()
+        if not candidate.exists():
+            errors.append(f"Broken internal link in index.html: {href}")
+
+custom_404 = ROOT / "404.html"
+if not custom_404.exists():
+    warnings.append("No 404.html page found; GitHub Pages fallback UX may be generic.")
+
+for warning in warnings:
+    print(f"WARN: {warning}")
+
+if errors:
+    print("Functional checks failed:")
+    for err in errors:
+        print(f"- {err}")
+    raise SystemExit(1)
+
+print("Functional checks passed.")

--- a/scripts/test_performance_budget.py
+++ b/scripts/test_performance_budget.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""File-size performance budget checks for static pages."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+MAX_SINGLE_ASSET_KB = 300
+MAX_TOTAL_KB = 1500
+INCLUDE_EXTENSIONS = {".html", ".css", ".js", ".json"}
+SKIP_DIRS = {".git"}
+
+tracked_files: list[Path] = []
+for path in ROOT.rglob("*"):
+    if path.is_dir():
+        continue
+    if any(part in SKIP_DIRS for part in path.parts):
+        continue
+    if path.suffix.lower() in INCLUDE_EXTENSIONS:
+        tracked_files.append(path)
+
+errors: list[str] = []
+total_bytes = 0
+
+for file_path in tracked_files:
+    size = file_path.stat().st_size
+    total_bytes += size
+    if size > MAX_SINGLE_ASSET_KB * 1024:
+        errors.append(
+            f"{file_path.relative_to(ROOT)} is {size / 1024:.1f} KB (limit {MAX_SINGLE_ASSET_KB} KB)"
+        )
+
+total_kb = total_bytes / 1024
+if total_kb > MAX_TOTAL_KB:
+    errors.append(f"Total tracked asset size {total_kb:.1f} KB exceeds {MAX_TOTAL_KB} KB")
+
+if errors:
+    print("Performance budget checks failed:")
+    for err in errors:
+        print(f"- {err}")
+    raise SystemExit(1)
+
+print(f"Performance budget checks passed. Total tracked size: {total_kb:.1f} KB")


### PR DESCRIPTION
### Motivation
- Provide a small, secure, and maintainable automated test plan for the static GitHub Pages site that validates content, accessibility, performance budget, and basic deployed security headers.
- Keep tests lightweight and free of heavy browser dependencies so checks are fast and reliable in CI for pull requests and pushes to `main`.

### Description
- Add a GitHub Actions workflow ` .github/workflows/site-test-plan.yml` with jobs for `content-integrity`, `static-quality`, and `security-headers` to run on PRs and pushes to `main`.
- Add small Python smoke-check scripts `scripts/test_functional.py`, `scripts/test_accessibility.py`, and `scripts/test_performance_budget.py` that validate required pages, internal links, basic accessibility attributes, and a file-size performance budget.
- Add a deploy-time header checker `scripts/check_security_headers.py` that validates required and recommended HTTP security headers for the GitHub Pages URL supplied via `SITE_URL`.
- Document the implementation and local run commands in `docs/test-plan-implementation.md` and integrate `markdownlint`/`lychee` checks in the CI `content-integrity` job.

### Testing
- Ran `python scripts/test_functional.py`, which passed and emitted a warning about a missing `404.html` file.
- Ran `python scripts/test_accessibility.py`, which passed the static accessibility baselines for the target pages.
- Ran `python scripts/test_performance_budget.py`, which passed and reported the tracked total size (small site footprint).
- Ran `scripts/check_security_headers.py` against the deployed URL but the fetch failed in this runtime due to an outbound proxy/tunnel returning `403 Forbidden`; the script is configured to run in CI against the actual GitHub Pages URL where it will perform the intended header validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e81b4391c48322b96f31a6f65fd68e)