### PR TITLE
Add Phase 1 checks, make summarizer resilient, and update CI to run checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,17 @@ Daily news briefing feed.
 
 
 Web page: `status-site/pptx-builder.html`
+
+
+## Phase 1 checks
+
+Run the baseline quality gate locally:
+
+```bash
+python scripts/run_phase1_checks.py
+```
+
+This executes:
+- site architecture contract validation
+- feed health test generation
+- latest briefing generation

--- a/generate_latest.py
+++ b/generate_latest.py
@@ -70,8 +70,11 @@ GROUPED_FEEDS = {
     ]
 }
 
-# Initialize summarizer once
-summarizer = pipeline("summarization")
+# Initialize summarizer once; gracefully degrade if model/task is unavailable
+try:
+    summarizer = pipeline("summarization")
+except Exception:
+    summarizer = None
 
 # Helper to strip HTML
 TAG_RE = re.compile(r'<[^>]+>')
@@ -86,6 +89,8 @@ def ai_summary(text):
     # Longer summary: up to 250 tokens, min 80
     max_len = min(len(words), 250)
     max_len = max(max_len, 80)
+    if summarizer is None:
+        return text
     try:
         result = summarizer(text, max_length=max_len, min_length=80, do_sample=False)
         return result[0]['summary_text'].strip()

--- a/news_pipeline.yml
+++ b/news_pipeline.yml
@@ -27,13 +27,11 @@ jobs:
 
       - name: Install Python dependencies
         run: |
-          pip install pyyaml requests openai
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
 
-      - name: List repository contents
-        run: ls -R .
-
-      - name: Run RSS feed tests
-        run: python test_feeds.py
+      - name: Run Phase 1 checks
+        run: python scripts/run_phase1_checks.py
 
       - name: Commit updated health.json
         uses: EndBug/add-and-commit@v9

--- a/scripts/run_phase1_checks.py
+++ b/scripts/run_phase1_checks.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Run Phase 1 repository checks with clear pass/fail output."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+CHECKS: list[tuple[str, list[str]]] = [
+    ("Architecture contract", [sys.executable, "scripts/validate_site_architecture.py"]),
+    ("Feed health test", [sys.executable, "test_feeds.py"]),
+    ("Brief generation", [sys.executable, "generate_latest.py"]),
+]
+
+
+def run_check(name: str, cmd: list[str]) -> int:
+    print(f"\n=== {name} ===")
+    print("$", " ".join(cmd))
+    result = subprocess.run(cmd, cwd=ROOT, check=False)
+    if result.returncode == 0:
+        print(f"PASS: {name}")
+    else:
+        print(f"FAIL: {name} (exit {result.returncode})")
+    return result.returncode
+
+
+def main() -> int:
+    failures = 0
+    for name, cmd in CHECKS:
+        failures += 1 if run_check(name, cmd) != 0 else 0
+
+    if failures:
+        print(f"\nPhase 1 checks failed: {failures} check(s) did not pass.")
+        return 1
+
+    print("\nAll Phase 1 checks passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation

- Introduce a lightweight Phase 1 quality gate to run baseline repository checks before generating the briefing.
- Ensure `generate_latest.py` degrades gracefully if the summarization pipeline or model is unavailable.
- Move CI to a reproducible dependency install via `requirements.txt` and run the new Phase 1 checks in the pipeline.

### Description

- Added `scripts/run_phase1_checks.py` which runs the architecture contract, feed health tests, and briefing generation with clear pass/fail output.
- Updated `generate_latest.py` to wrap the `pipeline("summarization")` initialization in a `try/except` and fall back to returning the cleaned text when unavailable, and to handle summarization errors gracefully.
- Updated `news_pipeline.yml` to install dependencies via `python -m pip install --upgrade pip` and `pip install -r requirements.txt` and to run `python scripts/run_phase1_checks.py` as part of the workflow before generating the briefing.
- Documented how to run the Phase 1 checks locally in `README.md` with the command `python scripts/run_phase1_checks.py`.

### Testing

- The CI workflow was updated to run `python scripts/run_phase1_checks.py` and `python generate_latest.py` during pipeline runs, but no CI run results are included with this change.
- No automated test results were produced as part of this PR review, so the runtime outcomes of the updated workflow and new script are unverified here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea083922fc8322acd449a3fed65b50)