### PR TITLE
Add custom 404 page for better GitHub Pages fallback UX

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Page Not Found · HC News Briefing Feed</title>
+  <meta name="description" content="The page you requested was not found. Return to the HC News Briefing Feed dashboard.">
+  <meta property="og:title" content="Page Not Found · HC News Briefing Feed">
+  <meta property="og:description" content="The page you requested was not found. Return to the HC News Briefing Feed dashboard.">
+  <meta property="og:image" content="assets/site-thumbnail.svg">
+  <meta property="og:type" content="website">
+  <meta name="twitter:card" content="summary_large_image">
+  <style>
+    :root {
+      --bg: #f8fafc;
+      --panel: #ffffff;
+      --text: #111827;
+      --muted: #4b5563;
+      --border: #d1d5db;
+      --brand: #0f766e;
+      --brand-soft: #ccfbf1;
+    }
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: grid;
+      place-items: center;
+      padding: 1.5rem;
+      background: var(--bg);
+      color: var(--text);
+      font-family: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      line-height: 1.55;
+    }
+    main {
+      max-width: 640px;
+      width: min(100%, 640px);
+      background: var(--panel);
+      border: 1px solid var(--border);
+      border-radius: 16px;
+      box-shadow: 0 10px 24px rgba(15, 23, 42, 0.08);
+      padding: 1.5rem;
+    }
+    .badge {
+      display: inline-block;
+      border: 1px solid #99f6e4;
+      color: #115e59;
+      background: #f0fdfa;
+      border-radius: 999px;
+      padding: 0.2rem 0.6rem;
+      font-weight: 700;
+      font-size: 0.8rem;
+      margin-bottom: 0.75rem;
+    }
+    h1 {
+      margin: 0 0 0.5rem;
+      font-size: clamp(1.4rem, 2.5vw, 2rem);
+    }
+    p {
+      margin: 0 0 1rem;
+      color: var(--muted);
+    }
+    .actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.75rem;
+      margin-top: 1rem;
+    }
+    .actions a {
+      text-decoration: none;
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      padding: 0.55rem 0.85rem;
+      color: var(--text);
+      font-weight: 600;
+      background: #fff;
+    }
+    .actions a.primary {
+      border-color: var(--brand);
+      background: var(--brand);
+      color: #fff;
+    }
+    .actions a:hover,
+    .actions a:focus-visible {
+      outline: none;
+      box-shadow: 0 0 0 3px var(--brand-soft);
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <span class="badge">404 · Not Found</span>
+    <h1>We can’t find that page.</h1>
+    <p>The link may be outdated, or the page may have moved. Use one of the shortcuts below to continue.</p>
+
+    <nav class="actions" aria-label="Recovery links">
+      <a class="primary" href="index.html">Go to Dashboard</a>
+      <a href="intelligence-editor.html">Intelligence Editor</a>
+      <a href="status-site/backlog.html">Status-Site Backlog</a>
+    </nav>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Provide a branded, user-friendly fallback for GitHub Pages to replace the generic 404 experience and remove the functional test warning about a missing custom 404.
- Surface clear recovery links so visitors can quickly navigate back to primary pages when a route is not found.

### Description
- Add a new `404.html` page with consistent site styling, metadata (title, description, Open Graph, and Twitter card), and accessible layout.
- Include prominent recovery links to `index.html`, `intelligence-editor.html`, and `status-site/backlog.html` to help users recover from broken URLs.
- Ensure the page follows existing visual tokens and simple responsive styles so it matches the rest of the site.

### Testing
- Ran the Phase 1 gate with `python scripts/run_phase1_checks.py` and it completed successfully with architecture, feed health, and brief generation checks passing.
- Executed functional, accessibility, and performance checks with `python scripts/test_functional.py`, `python scripts/test_accessibility.py`, and `python scripts/test_performance_budget.py`, and all passed.
- Verified the functional test warning about a missing `404.html` is resolved by the new file.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea6039bd208322aea708bf73c6459e)