### PR TITLE
Fix Excalidraw EA launcher redirect on GitHub Pages

### DIFF
--- a/status-site/excalidraw-ea.html
+++ b/status-site/excalidraw-ea.html
@@ -5,10 +5,10 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Excalidraw EA Launcher</title>
   <meta name="description" content="Launcher for the Excalidraw editor used by Diagram Lab.">
-  <meta http-equiv="refresh" content="0; url=/status-site/diagram-lab.html">
-  <link rel="canonical" href="/status-site/diagram-lab.html">
+  <meta http-equiv="refresh" content="0; url=diagram-lab.html">
+  <link rel="canonical" href="diagram-lab.html">
 </head>
 <body>
-  <p>Redirecting to <a href="/status-site/diagram-lab.html">Diagram Lab</a>…</p>
+  <p>Redirecting to <a href="diagram-lab.html">Diagram Lab</a>…</p>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- The launcher used root-relative `/status-site/diagram-lab.html` links which break when the site is served as a project page, so the redirect and canonical link must be relative to work under project-hosted GitHub Pages.

### Description
- Updated `status-site/excalidraw-ea.html` to use the relative target `diagram-lab.html` for the `meta refresh`, `link rel="canonical"`, and the fallback anchor.

### Testing
- Verified the change only modifies `status-site/excalidraw-ea.html` and inspected the file to confirm all `/status-site/diagram-lab.html` references were replaced with `diagram-lab.html`, and the checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eab7405d5c8322b4e112e19b8a0c9a)